### PR TITLE
fix: robust factory restart and widget display after UNS import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application source
 COPY . .
 
-# Make entrypoint executable
-RUN chmod +x /app/entrypoint.sh
+# Strip Windows CRLF line endings and make executable
+RUN sed -i 's/\r//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # /data is the persistent volume mount point for runtime config files
 VOLUME /data

--- a/app.py
+++ b/app.py
@@ -571,6 +571,7 @@ def stop_factory_server():
             proc.wait(timeout=6)
         except subprocess.TimeoutExpired:
             proc.kill()
+            proc.wait()  # Ensure OS reclaims the process (and its sockets) before returning
         _state['server_proc'] = None
         return True, "Server stopped"
 
@@ -1155,7 +1156,12 @@ def api_uns_save():
         _state['opc_connected'] = False
         time.sleep(1)
         stop_factory_server()
+        time.sleep(1)  # Let OS release port 4840 before binding again
         ok, _ = start_factory_server()
+        if not ok:
+            # First attempt failed (port still in TIME_WAIT) — retry once after a longer wait
+            time.sleep(3)
+            ok, _ = start_factory_server()
         if ok:
             restarted.append('factory')
             # Invalidate metric path cache so new UNS structure is picked up

--- a/app.py
+++ b/app.py
@@ -359,6 +359,8 @@ def _collect_plant_data(ent, idx):
 
     def _read_path(path):
         """Read an OPC value given a path list starting from enterprise root."""
+        if not path:
+            return 0.0
         try:
             node = ent
             for part in path:
@@ -398,11 +400,13 @@ def _collect_plant_data(ent, idx):
                     pass
 
             if not site_exists:
-                # Site not in OPC tree yet (server still starting) — use sim_state only
+                # Site not in OPC tree yet (server still starting) — opc_ready=False
+                # tells the dashboard to show '--' instead of misleading zeros
                 plants[plant_key] = {
                     'group': group, 'plant': plant,
                     'process_state': process_state, 'recipe': recipe,
                     'maint_status': 'Running' if process_state else 'Stopped',
+                    'opc_ready': False,
                     'oee': 0.0, 'power': 0.0, 'good_tons': 0.0, 'trucks_recv': 0.0,
                 }
                 continue
@@ -415,6 +419,7 @@ def _collect_plant_data(ent, idx):
                 'process_state': process_state,
                 'recipe':        recipe,
                 'maint_status':  'Running' if process_state else 'Stopped',
+                'opc_ready':     True,
                 'oee':        _num(_read_path(metric_paths.get('oee',        []))),
                 'power':      _num(_read_path(metric_paths.get('power',      []))),
                 'good_tons':  _num(_read_path(metric_paths.get('good_tons',  []))),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
 
   uns-simulator:
+    build: .
     image: uns-simulator:latest
     container_name: uns-simulator
     restart: unless-stopped

--- a/templates/index.html
+++ b/templates/index.html
@@ -610,17 +610,18 @@ function updateCards(plants) {
     recipe.textContent = rec;
     recipe.title = rec;
 
-    // OEE
-    const oee = p.oee;
-    oeeEl.textContent = running ? `${oee}%` : '--';
+    // OEE — only show live values when OPC data is confirmed ready
+    const oee  = p.oee;
+    const live = running && p.opc_ready !== false;
+    oeeEl.textContent = live ? `${oee}%` : '--';
     oeeEl.className = 'metric-value ' + (oee >= 80 ? 'oee-high' : oee >= 60 ? 'oee-mid' : 'oee-low');
-    bar.style.width = running ? `${Math.min(oee,100)}%` : '0%';
+    bar.style.width = live ? `${Math.min(oee,100)}%` : '0%';
     bar.style.background = oee >= 80 ? 'var(--green)' : oee >= 60 ? 'var(--yellow)' : 'var(--red)';
 
     // Metrics
-    pwrEl.textContent  = running ? `${p.power} kW`  : '--';
-    goodEl.textContent = running ? `${p.good_tons}` : '--';
-    trEl.textContent   = `${p.trucks_recv}`;
+    pwrEl.textContent  = live ? `${p.power} kW`  : '--';
+    goodEl.textContent = live ? `${p.good_tons}` : '--';
+    trEl.textContent   = live ? `${p.trucks_recv}` : '--';
   }
 }
 


### PR DESCRIPTION
# Summary
 When a new company is imported and saved in UNS Design Studio, the app restarts the OPC-UA factory server to apply the new configuration.
  This PR fixes two related problems that made that workflow unreliable: (1) dashboard metric cards flashed zeros instead of dashes while the server was still initializing, and (2) plants became unresponsive after the restart and required a full `docker compose restart` to recover. 
  It also fixes a Docker build issue where `--build` silently did nothing, and a container startup crash on Linux caused by Windows line endings in the entrypoint script.

# Changes
  - Factory widgets showed 0%/0 kW instead of -- during OPC init after import → added opc_ready flag, gated JS display on `running &&  opc_ready !== false`
  - `_read_path([])` hit enterprise folder node instead of returning 0 → early return on empty path
  - Plants stuck after in-session factory restart (port 4840 TIME_WAIT) → `proc.wait()` after kill, 1 s gap, retry after 3 s
  - `--build` flag not rebuilding → added `build: .` to `docker-compose.yml`
  - `exec format error` on container start → strip CRLF in Dockerfile before `chmod +x` (applied for Windows platform, safe for Linux/Mac)