### PR TITLE
Feature: light theme toggle across all pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application source
 COPY . .
 
-# Make entrypoint executable
-RUN chmod +x /app/entrypoint.sh
+# Strip Windows CRLF line endings and make executable
+RUN sed -i 's/\r//' /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 
 # /data is the persistent volume mount point for runtime config files
 VOLUME /data

--- a/app.py
+++ b/app.py
@@ -571,6 +571,7 @@ def stop_factory_server():
             proc.wait(timeout=6)
         except subprocess.TimeoutExpired:
             proc.kill()
+            proc.wait()  # Ensure OS reclaims the process (and its sockets) before returning
         _state['server_proc'] = None
         return True, "Server stopped"
 
@@ -1155,7 +1156,12 @@ def api_uns_save():
         _state['opc_connected'] = False
         time.sleep(1)
         stop_factory_server()
+        time.sleep(1)  # Let OS release port 4840 before binding again
         ok, _ = start_factory_server()
+        if not ok:
+            # First attempt failed (port still in TIME_WAIT) — retry once after a longer wait
+            time.sleep(3)
+            ok, _ = start_factory_server()
         if ok:
             restarted.append('factory')
             # Invalidate metric path cache so new UNS structure is picked up

--- a/app.py
+++ b/app.py
@@ -359,6 +359,8 @@ def _collect_plant_data(ent, idx):
 
     def _read_path(path):
         """Read an OPC value given a path list starting from enterprise root."""
+        if not path:
+            return 0.0
         try:
             node = ent
             for part in path:
@@ -398,11 +400,13 @@ def _collect_plant_data(ent, idx):
                     pass
 
             if not site_exists:
-                # Site not in OPC tree yet (server still starting) — use sim_state only
+                # Site not in OPC tree yet (server still starting) — opc_ready=False
+                # tells the dashboard to show '--' instead of misleading zeros
                 plants[plant_key] = {
                     'group': group, 'plant': plant,
                     'process_state': process_state, 'recipe': recipe,
                     'maint_status': 'Running' if process_state else 'Stopped',
+                    'opc_ready': False,
                     'oee': 0.0, 'power': 0.0, 'good_tons': 0.0, 'trucks_recv': 0.0,
                 }
                 continue
@@ -415,6 +419,7 @@ def _collect_plant_data(ent, idx):
                 'process_state': process_state,
                 'recipe':        recipe,
                 'maint_status':  'Running' if process_state else 'Stopped',
+                'opc_ready':     True,
                 'oee':        _num(_read_path(metric_paths.get('oee',        []))),
                 'power':      _num(_read_path(metric_paths.get('power',      []))),
                 'good_tons':  _num(_read_path(metric_paths.get('good_tons',  []))),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
 
   uns-simulator:
+    build: .
     image: uns-simulator:latest
     container_name: uns-simulator
     restart: unless-stopped

--- a/templates/index.html
+++ b/templates/index.html
@@ -170,7 +170,7 @@ body{display:flex;flex-direction:column;min-height:100vh}
 .btn-ctrl:hover{border-color:var(--accent);color:var(--accent)}
 .btn-anomaly{flex:1;background:var(--surface3);border:1px solid var(--border);
   color:var(--yellow);padding:5px 0;font-size:12px}
-.btn-anomaly:hover{border-color:var(--yellow);background:#2d2506}
+.btn-anomaly:hover{border-color:var(--yellow);background:rgba(227,179,65,.15)}
 
 /* ── Log panel ───────────────────────────────────────────────────────────── */
 .log-panel{border-top:1px solid var(--border);background:var(--surface);flex-shrink:0}

--- a/templates/index.html
+++ b/templates/index.html
@@ -610,17 +610,18 @@ function updateCards(plants) {
     recipe.textContent = rec;
     recipe.title = rec;
 
-    // OEE
-    const oee = p.oee;
-    oeeEl.textContent = running ? `${oee}%` : '--';
+    // OEE — only show live values when OPC data is confirmed ready
+    const oee  = p.oee;
+    const live = running && p.opc_ready !== false;
+    oeeEl.textContent = live ? `${oee}%` : '--';
     oeeEl.className = 'metric-value ' + (oee >= 80 ? 'oee-high' : oee >= 60 ? 'oee-mid' : 'oee-low');
-    bar.style.width = running ? `${Math.min(oee,100)}%` : '0%';
+    bar.style.width = live ? `${Math.min(oee,100)}%` : '0%';
     bar.style.background = oee >= 80 ? 'var(--green)' : oee >= 60 ? 'var(--yellow)' : 'var(--red)';
 
     // Metrics
-    pwrEl.textContent  = running ? `${p.power} kW`  : '--';
-    goodEl.textContent = running ? `${p.good_tons}` : '--';
-    trEl.textContent   = `${p.trucks_recv}`;
+    pwrEl.textContent  = live ? `${p.power} kW`  : '--';
+    goodEl.textContent = live ? `${p.good_tons}` : '--';
+    trEl.textContent   = live ? `${p.trucks_recv}` : '--';
   }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -92,8 +92,8 @@ body{display:flex;flex-direction:column;min-height:100vh}
 .bridge-sep{width:1px;height:18px;background:var(--border)}
 .proto-badge{font-size:11px;font-weight:700;padding:2px 8px;border-radius:10px;
   letter-spacing:.05em;white-space:nowrap}
-.proto-badge.nats{background:rgba(163,113,247,.15);color:var(--purple);border:1px solid rgba(163,113,247,.3)}
-.proto-badge.mqtt{background:rgba(88,166,255,.15);color:var(--accent);border:1px solid rgba(88,166,255,.3)}
+.proto-badge.nats{background:color-mix(in srgb, var(--purple) 15%, transparent);color:var(--purple);border:1px solid color-mix(in srgb, var(--purple) 30%, transparent)}
+.proto-badge.mqtt{background:color-mix(in srgb, var(--accent) 15%, transparent);color:var(--accent);border:1px solid color-mix(in srgb, var(--accent) 30%, transparent)}
 .proto-badge.off{background:var(--surface3);color:var(--muted);border:1px solid var(--border)}
 .bridge-addr{font-size:11px;color:var(--muted);font-family:monospace}
 .bridge-stat{font-size:11px;color:var(--muted)}
@@ -130,7 +130,7 @@ body{display:flex;flex-direction:column;min-height:100vh}
 .factories-grid{display:flex;flex-wrap:wrap;gap:12px}
 .factory-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);
   width:220px;display:flex;flex-direction:column;transition:border-color .3s,box-shadow .3s}
-.factory-card:hover{border-color:var(--accent);box-shadow:0 0 0 1px rgba(88,166,255,.2)}
+.factory-card:hover{border-color:var(--accent);box-shadow:0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent)}
 .factory-card.status-running{border-left:3px solid var(--green)}
 .factory-card.status-down{border-left:3px solid var(--yellow)}
 .factory-card.status-stopped{border-left:3px solid var(--muted)}
@@ -170,7 +170,7 @@ body{display:flex;flex-direction:column;min-height:100vh}
 .btn-ctrl:hover{border-color:var(--accent);color:var(--accent)}
 .btn-anomaly{flex:1;background:var(--surface3);border:1px solid var(--border);
   color:var(--yellow);padding:5px 0;font-size:12px}
-.btn-anomaly:hover{border-color:var(--yellow);background:rgba(227,179,65,.15)}
+.btn-anomaly:hover{border-color:var(--yellow);background:color-mix(in srgb, var(--yellow) 15%, transparent)}
 
 /* ── Log panel ───────────────────────────────────────────────────────────── */
 .log-panel{border-top:1px solid var(--border);background:var(--surface);flex-shrink:0}
@@ -216,8 +216,8 @@ body{display:flex;flex-direction:column;min-height:100vh}
 
 .toggle-row{display:flex;gap:8px;margin-bottom:14px}
 .toggle-btn{flex:1;padding:8px;border:2px solid var(--border);background:var(--surface2);color:var(--muted);font-weight:600}
-.toggle-btn.active-on{border-color:var(--green);color:var(--green);background:rgba(63,185,80,.12)}
-.toggle-btn.active-off{border-color:var(--red);color:var(--red);background:rgba(248,81,73,.12)}
+.toggle-btn.active-on{border-color:var(--green);color:var(--green);background:color-mix(in srgb, var(--green) 12%, transparent)}
+.toggle-btn.active-off{border-color:var(--red);color:var(--red);background:color-mix(in srgb, var(--red) 12%, transparent)}
 
 .checkbox-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(90px,1fr));gap:6px;max-height:140px;overflow-y:auto}
 .cb-item{display:flex;align-items:center;gap:6px;padding:4px 8px;
@@ -248,10 +248,10 @@ body{display:flex;flex-direction:column;min-height:100vh}
 #toasts{position:fixed;bottom:20px;right:20px;display:flex;flex-direction:column;gap:8px;z-index:999}
 .toast{padding:10px 16px;border-radius:8px;font-size:13px;font-weight:600;
   animation:slideIn .3s ease;max-width:300px;box-shadow:var(--shadow)}
-.toast.success{background:rgba(63,185,80,.15);border:1px solid var(--green);color:var(--green)}
-.toast.error{background:rgba(248,81,73,.15);border:1px solid var(--red);color:var(--red)}
-.toast.info{background:rgba(88,166,255,.15);border:1px solid var(--accent);color:var(--accent)}
-.toast.warn{background:rgba(227,179,65,.15);border:1px solid var(--yellow);color:var(--yellow)}
+.toast.success{background:color-mix(in srgb, var(--green) 15%, transparent);border:1px solid var(--green);color:var(--green)}
+.toast.error{background:color-mix(in srgb, var(--red) 15%, transparent);border:1px solid var(--red);color:var(--red)}
+.toast.info{background:color-mix(in srgb, var(--accent) 15%, transparent);border:1px solid var(--accent);color:var(--accent)}
+.toast.warn{background:color-mix(in srgb, var(--yellow) 15%, transparent);border:1px solid var(--yellow);color:var(--yellow)}
 @keyframes slideIn{from{opacity:0;transform:translateX(40px)}to{opacity:1;transform:none}}
 
 /* ── Scrollbar ────────────────────────────────────────────────────────────── */

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,24 @@
   --purple:#a371f7;
   --radius:8px;
   --shadow:0 4px 16px rgba(0,0,0,.5);
+  --on-accent:#0d1117;
+}
+[data-theme="light"]{
+  --bg:#f6f8fa;
+  --surface:#ffffff;
+  --surface2:#f0f2f5;
+  --surface3:#e8ebef;
+  --border:#d0d7de;
+  --text:#1f2328;
+  --muted:#656d76;
+  --accent:#0969da;
+  --green:#1a7f37;
+  --red:#cf222e;
+  --yellow:#9a6700;
+  --orange:#953800;
+  --purple:#8250df;
+  --shadow:0 4px 16px rgba(0,0,0,.1);
+  --on-accent:#ffffff;
 }
 html,body{height:100%;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;
   background:var(--bg);color:var(--text);font-size:14px;line-height:1.5}
@@ -93,7 +111,7 @@ body{display:flex;flex-direction:column;min-height:100vh}
 .proto-toggle{display:flex;gap:0;border:1px solid var(--border);border-radius:6px;overflow:hidden;margin-bottom:16px}
 .proto-btn{flex:1;padding:8px;font-size:13px;font-weight:600;background:var(--surface3);
   color:var(--muted);border-radius:0;border:none;transition:all .15s}
-.proto-btn.on{background:var(--accent);color:#0d1117}
+.proto-btn.on{background:var(--accent);color:var(--on-accent)}
 
 /* ── Main content ────────────────────────────────────────────────────────── */
 .main-content{flex:1;padding:20px;overflow-y:auto}
@@ -164,9 +182,9 @@ body{display:flex;flex-direction:column;min-height:100vh}
   background:var(--bg);border-top:1px solid var(--border);padding:8px 20px}
 .log-body.open{display:block}
 .log-body pre{font-family:'Cascadia Code','Fira Code','Consolas',monospace;font-size:11px;
-  color:#8b949e;line-height:1.6;white-space:pre-wrap;word-break:break-all}
-.log-body pre .log-info{color:#58a6ff}
-.log-body pre .log-err{color:#f85149}
+  color:var(--muted);line-height:1.6;white-space:pre-wrap;word-break:break-all}
+.log-body pre .log-info{color:var(--accent)}
+.log-body pre .log-err{color:var(--red)}
 .log-actions{display:flex;gap:8px;padding:6px 20px;border-top:1px solid var(--border)}
 .btn-log{background:none;border:1px solid var(--border);color:var(--muted);padding:3px 10px;font-size:11px}
 .btn-log:hover{color:var(--text);border-color:var(--text)}
@@ -198,8 +216,8 @@ body{display:flex;flex-direction:column;min-height:100vh}
 
 .toggle-row{display:flex;gap:8px;margin-bottom:14px}
 .toggle-btn{flex:1;padding:8px;border:2px solid var(--border);background:var(--surface2);color:var(--muted);font-weight:600}
-.toggle-btn.active-on{border-color:var(--green);color:var(--green);background:#0d2e18}
-.toggle-btn.active-off{border-color:var(--red);color:var(--red);background:#2d0c0c}
+.toggle-btn.active-on{border-color:var(--green);color:var(--green);background:rgba(63,185,80,.12)}
+.toggle-btn.active-off{border-color:var(--red);color:var(--red);background:rgba(248,81,73,.12)}
 
 .checkbox-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(90px,1fr));gap:6px;max-height:140px;overflow-y:auto}
 .cb-item{display:flex;align-items:center;gap:6px;padding:4px 8px;
@@ -207,7 +225,7 @@ body{display:flex;flex-direction:column;min-height:100vh}
 .cb-item input{width:14px;height:14px;cursor:pointer;accent-color:var(--accent)}
 .cb-item:hover{border-color:var(--accent)}
 
-.btn-primary{background:var(--accent);color:#0d1117;padding:8px 20px;font-weight:700}
+.btn-primary{background:var(--accent);color:var(--on-accent);padding:8px 20px;font-weight:700}
 .btn-primary:hover{opacity:.9}
 .btn-danger{background:#8b1a1a;color:#fff;padding:8px 20px;font-weight:700}
 .btn-danger:hover{background:var(--red)}
@@ -241,7 +259,12 @@ body{display:flex;flex-direction:column;min-height:100vh}
 ::-webkit-scrollbar-track{background:var(--surface)}
 ::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
 ::-webkit-scrollbar-thumb:hover{background:var(--muted)}
+.btn-theme{background:var(--surface2);border:1px solid var(--border);color:var(--muted);padding:6px 10px;border-radius:6px;font-size:13px}
+.btn-theme:hover{border-color:var(--accent);color:var(--accent)}
+.btn-theme::before{content:'Light'}
+[data-theme="light"] .btn-theme::before{content:'Dark'}
 </style>
+<script>(function(){var t=localStorage.getItem('uns-theme')||'dark';document.documentElement.setAttribute('data-theme',t);})();</script>
 </head>
 <body>
 
@@ -270,6 +293,7 @@ body{display:flex;flex-direction:column;min-height:100vh}
     <a href="/payload-schemas" style="background:var(--surface3);color:var(--text);border:1px solid var(--border);padding:6px 12px;border-radius:6px;font-size:13px;text-decoration:none;white-space:nowrap" title="Open Payload Schema Designer">⚙️ Payload Schemas</a>
     <button style="background:var(--surface2);color:var(--text);border:1px solid var(--border);padding:6px 12px;border-radius:6px;font-size:13px;cursor:pointer" onclick="openSettings()" title="Network &amp; server settings">🔧 Settings</button>
     <button style="background:var(--surface2);color:var(--muted);border:1px solid var(--border);padding:6px 12px;border-radius:6px;font-size:13px;cursor:pointer" onclick="document.getElementById('about-modal').style.display='flex'" title="About">ℹ️</button>
+    <button class="btn-theme" onclick="toggleTheme()" title="Toggle light/dark theme"></button>
     <button class="btn-server-start" onclick="serverStart()">▶ Start Server</button>
     <button class="btn-server-stop" onclick="serverStop()">■ Stop Server</button>
   </div>
@@ -1104,6 +1128,12 @@ async function saveBridgeCfg() {
   }
 }
 
+function toggleTheme() {
+  const next = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('uns-theme', next);
+}
+
 // ── Boot ───────────────────────────────────────────────────────────────────────
 startPolling();
 </script>
@@ -1151,7 +1181,7 @@ startPolling();
     </div>
 
     <button onclick="document.getElementById('about-modal').style.display='none'"
-            style="background:var(--accent);color:#0d1117;border:none;border-radius:6px;padding:8px 24px;font-size:13px;font-weight:600;cursor:pointer">
+            style="background:var(--accent);color:var(--on-accent);border:none;border-radius:6px;padding:8px 24px;font-size:13px;font-weight:600;cursor:pointer">
       Close
     </button>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -248,10 +248,10 @@ body{display:flex;flex-direction:column;min-height:100vh}
 #toasts{position:fixed;bottom:20px;right:20px;display:flex;flex-direction:column;gap:8px;z-index:999}
 .toast{padding:10px 16px;border-radius:8px;font-size:13px;font-weight:600;
   animation:slideIn .3s ease;max-width:300px;box-shadow:var(--shadow)}
-.toast.success{background:#0d2e18;border:1px solid var(--green);color:var(--green)}
-.toast.error{background:#2d0c0c;border:1px solid var(--red);color:var(--red)}
-.toast.info{background:#0c1d32;border:1px solid var(--accent);color:var(--accent)}
-.toast.warn{background:#2d2506;border:1px solid var(--yellow);color:var(--yellow)}
+.toast.success{background:rgba(63,185,80,.15);border:1px solid var(--green);color:var(--green)}
+.toast.error{background:rgba(248,81,73,.15);border:1px solid var(--red);color:var(--red)}
+.toast.info{background:rgba(88,166,255,.15);border:1px solid var(--accent);color:var(--accent)}
+.toast.warn{background:rgba(227,179,65,.15);border:1px solid var(--yellow);color:var(--yellow)}
 @keyframes slideIn{from{opacity:0;transform:translateX(40px)}to{opacity:1;transform:none}}
 
 /* ── Scrollbar ────────────────────────────────────────────────────────────── */

--- a/templates/payload_schemas.html
+++ b/templates/payload_schemas.html
@@ -18,6 +18,22 @@
       --red: #f85149;
       --yellow: #d29922;
       --purple: #a371f7;
+      --on-accent: #ffffff;
+    }
+    [data-theme="light"] {
+      --bg: #f6f8fa;
+      --surface: #ffffff;
+      --surface2: #f0f2f5;
+      --border: #d0d7de;
+      --text: #1f2328;
+      --text-muted: #656d76;
+      --accent: #0969da;
+      --accent-dim: #0969da;
+      --green: #1a7f37;
+      --red: #cf222e;
+      --yellow: #9a6700;
+      --purple: #8250df;
+      --on-accent: #ffffff;
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
@@ -70,7 +86,7 @@
     /* ── Buttons ── */
     .btn-primary {
       background: var(--accent-dim);
-      color: #fff;
+      color: var(--on-accent);
       border: none;
       border-radius: 4px;
       padding: 6px 14px;
@@ -293,13 +309,13 @@
       cursor: pointer;
       user-select: none;
     }
-    .preview-header:hover { background: #2a2f37; }
+    .preview-header:hover { background: var(--surface2); }
     .preview-toggle {
       font-size: 11px;
       color: var(--text-muted);
     }
     #preview-json {
-      background: #0d1117;
+      background: var(--bg);
       border: none;
       border-radius: 0;
       padding: 12px;
@@ -368,7 +384,12 @@
     ::-webkit-scrollbar-track { background: transparent; }
     ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
     ::-webkit-scrollbar-thumb:hover { background: #484f58; }
+    .btn-theme{background:var(--surface2);border:1px solid var(--border);color:var(--text-muted);padding:5px 10px;border-radius:6px;font-size:13px;cursor:pointer}
+    .btn-theme:hover{border-color:var(--accent);color:var(--accent)}
+    .btn-theme::before{content:'Light'}
+    [data-theme="light"] .btn-theme::before{content:'Dark'}
   </style>
+  <script>(function(){var t=localStorage.getItem('uns-theme')||'dark';document.documentElement.setAttribute('data-theme',t);})();</script>
 </head>
 <body>
 
@@ -376,6 +397,7 @@
   <a href="/">← Dashboard</a>
   <h1>⚙️ Payload Schema Designer</h1>
   <a href="/uns">🌐 UNS Designer</a>
+  <button class="btn-theme" onclick="toggleTheme()" title="Toggle light/dark theme"></button>
   <button class="btn-primary" id="btn-save-all">💾 Save All</button>
   <span id="save-ind">● Unsaved</span>
 </header>
@@ -783,6 +805,12 @@
   }
 
   loadSchemas();
+
+  function toggleTheme() {
+    const next = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('uns-theme', next);
+  }
 </script>
 </body>
 </html>

--- a/templates/payload_schemas.html
+++ b/templates/payload_schemas.html
@@ -116,7 +116,7 @@
       font-size: 13px;
       transition: color 0.15s, background 0.15s;
     }
-    .btn-icon:hover { color: var(--red); background: rgba(248,81,73,0.12); }
+    .btn-icon:hover { color: var(--red); background: color-mix(in srgb, var(--red) 12%, transparent); }
 
     /* ── Main layout ── */
     .main {
@@ -265,7 +265,7 @@
       border-bottom: 1px solid var(--border);
     }
     .fields-table tbody tr:nth-child(odd) { background: transparent; }
-    .fields-table tbody tr:nth-child(even) { background: rgba(33,38,45,0.5); }
+    .fields-table tbody tr:nth-child(even) { background: var(--surface2); }
     .fields-table tbody tr:hover { background: var(--surface2); }
     .fields-table td {
       padding: 6px 8px;

--- a/templates/uns_editor.html
+++ b/templates/uns_editor.html
@@ -30,6 +30,24 @@
       --purple: #a371f7;
       --radius: 8px;
       --shadow: 0 4px 16px rgba(0, 0, 0, .5);
+      --on-accent: #0d1117;
+    }
+    [data-theme="light"] {
+      --bg: #f6f8fa;
+      --surface: #ffffff;
+      --surface2: #f0f2f5;
+      --surface3: #e8ebef;
+      --border: #d0d7de;
+      --text: #1f2328;
+      --muted: #656d76;
+      --accent: #0969da;
+      --green: #1a7f37;
+      --red: #cf222e;
+      --yellow: #9a6700;
+      --orange: #953800;
+      --purple: #8250df;
+      --shadow: 0 4px 16px rgba(0, 0, 0, .1);
+      --on-accent: #ffffff;
     }
 
     html,
@@ -146,7 +164,7 @@
 
     .btn-primary {
       background: var(--accent);
-      color: #0d1117
+      color: var(--on-accent)
     }
 
     .btn-secondary {
@@ -807,7 +825,12 @@
       background: var(--border);
       border-radius: 3px
     }
+    .btn-theme{background:var(--surface2);border:1px solid var(--border);color:var(--muted);padding:5px 10px;border-radius:6px;font-size:13px}
+    .btn-theme:hover{border-color:var(--accent);color:var(--accent)}
+    .btn-theme::before{content:'Light'}
+    [data-theme="light"] .btn-theme::before{content:'Dark'}
   </style>
+  <script>(function(){var t=localStorage.getItem('uns-theme')||'dark';document.documentElement.setAttribute('data-theme',t);})();</script>
 </head>
 
 <body>
@@ -823,6 +846,7 @@
     <button class="btn btn-ghost" onclick="doExportPaths()">📋 Topic Paths</button>
     <button class="btn btn-primary" id="btn-save" onclick="saveConfig()">💾 Save</button>
     <a href="/payload-schemas" class="btn btn-ghost">⚙️ Payload Schemas</a>
+    <button class="btn-theme" onclick="toggleTheme()" title="Toggle light/dark theme"></button>
     <a href="/" class="btn btn-ghost">← Dashboard</a>
   </header>
 
@@ -1936,6 +1960,12 @@
         localStorage.removeItem(KEY);
       });
     })();
+
+    function toggleTheme() {
+      const next = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem('uns-theme', next);
+    }
 
     // ── Boot ────────────────────────────────────────────────────────────────────────
     Promise.all([loadSchemas(), loadProfileCatalogue(), loadAssetLibrary()]).then(loadConfig);

--- a/templates/uns_editor.html
+++ b/templates/uns_editor.html
@@ -173,17 +173,32 @@
 
     /* Layout */
     .layout {
-      display: grid;
-      grid-template-columns: 360px 1fr;
+      display: flex;
       height: calc(100vh - 50px);
       overflow: hidden
+    }
+
+    /* Resize handle */
+    .resize-handle {
+      width: 4px;
+      background: var(--border);
+      cursor: col-resize;
+      flex-shrink: 0;
+      transition: background .15s
+    }
+    .resize-handle:hover,
+    .resize-handle.dragging {
+      background: var(--accent)
     }
 
     /* Tree panel */
     .tree-panel {
       display: flex;
       flex-direction: column;
-      border-right: 1px solid var(--border);
+      width: 320px;
+      min-width: 160px;
+      max-width: 70vw;
+      flex-shrink: 0;
       overflow: hidden;
       background: var(--bg)
     }
@@ -334,13 +349,15 @@
 
     .t-children {
       border-left: 1px solid var(--surface3);
-      margin-left: 19px
+      margin-left: 13px
     }
 
     /* Props panel */
     .props-panel {
       display: flex;
       flex-direction: column;
+      flex: 1;
+      min-width: 0;
       overflow: hidden
     }
 
@@ -824,6 +841,8 @@
       <div class="tree-stats" id="stats"></div>
     </div>
 
+    <div class="resize-handle" id="tree-resize"></div>
+
     <!-- Right: props -->
     <div class="props-panel" id="props-panel">
       <div class="props-empty" id="props-empty">
@@ -1087,7 +1106,7 @@
 
       const row = document.createElement('div');
       row.className = 't-row' + (isSel ? ' sel' : '');
-      row.style.paddingLeft = `${depth * 18 + 6}px`;
+      row.style.paddingLeft = `${depth * 12 + 6}px`;
       row.onclick = () => selNode(node.id);
 
       const tc2 = NT[tc.next] || NT.device;
@@ -1883,6 +1902,40 @@
       if (e.key === 'Escape') document.querySelectorAll('.overlay').forEach(m => m.style.display = 'none');
       if ((e.ctrlKey || e.metaKey) && e.key === 's') { e.preventDefault(); saveConfig(); }
     });
+
+    // ── Panel resize ────────────────────────────────────────────────────────────
+    (function() {
+      const handle = document.getElementById('tree-resize');
+      const panel  = document.querySelector('.tree-panel');
+      const KEY    = 'uns-tree-width';
+      const saved  = localStorage.getItem(KEY);
+      const w = parseInt(saved, 10);
+      if (w > 0) panel.style.width = w + 'px';
+      let dragging = false, x0 = 0, w0 = 0;
+      handle.addEventListener('mousedown', e => {
+        dragging = true; x0 = e.clientX; w0 = panel.offsetWidth;
+        handle.classList.add('dragging');
+        document.body.style.cursor = 'col-resize';
+        document.body.style.userSelect = 'none';
+        e.preventDefault();
+      });
+      document.addEventListener('mousemove', e => {
+        if (!dragging) return;
+        panel.style.width = Math.max(160, Math.min(w0 + e.clientX - x0, window.innerWidth * 0.7)) + 'px';
+      });
+      document.addEventListener('mouseup', () => {
+        if (!dragging) return;
+        dragging = false;
+        handle.classList.remove('dragging');
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        localStorage.setItem(KEY, panel.offsetWidth);
+      });
+      handle.addEventListener('dblclick', () => {
+        panel.style.width = '320px';
+        localStorage.removeItem(KEY);
+      });
+    })();
 
     // ── Boot ────────────────────────────────────────────────────────────────────────
     Promise.all([loadSchemas(), loadProfileCatalogue(), loadAssetLibrary()]).then(loadConfig);

--- a/templates/uns_editor.html
+++ b/templates/uns_editor.html
@@ -145,12 +145,12 @@
     }
 
     #save-ind.saved {
-      background: rgba(63, 185, 80, .12);
+      background: color-mix(in srgb, var(--green) 12%, transparent);
       color: var(--green)
     }
 
     #save-ind.unsaved {
-      background: rgba(227, 179, 65, .12);
+      background: color-mix(in srgb, var(--yellow) 12%, transparent);
       color: var(--yellow)
     }
 
@@ -174,9 +174,9 @@
     }
 
     .btn-danger {
-      background: rgba(248, 81, 73, .12);
+      background: color-mix(in srgb, var(--red) 12%, transparent);
       color: var(--red);
-      border: 1px solid rgba(248, 81, 73, .25)
+      border: 1px solid color-mix(in srgb, var(--red) 25%, transparent)
     }
 
     .btn-ghost {
@@ -361,7 +361,7 @@
     }
 
     .ibtn.del:hover {
-      background: rgba(248, 81, 73, .15);
+      background: color-mix(in srgb, var(--red) 15%, transparent);
       color: var(--red)
     }
 
@@ -516,11 +516,11 @@
       white-space: nowrap
     }
     .btn-asset {
-      background: rgba(163,113,247,.15);
+      background: color-mix(in srgb, var(--purple) 15%, transparent);
       color: var(--purple);
-      border: 1px solid rgba(163,113,247,.35)
+      border: 1px solid color-mix(in srgb, var(--purple) 35%, transparent)
     }
-    .btn-asset:hover { background: rgba(163,113,247,.25) }
+    .btn-asset:hover { background: color-mix(in srgb, var(--purple) 25%, transparent) }
 
     /* Sim cell clickable hint */
     .sim-cell {
@@ -704,19 +704,19 @@
     }
 
     .toast.ok {
-      background: rgba(63,185,80,.15);
+      background: color-mix(in srgb, var(--green) 15%, transparent);
       border: 1px solid var(--green);
       color: var(--green)
     }
 
     .toast.err {
-      background: rgba(248,81,73,.15);
+      background: color-mix(in srgb, var(--red) 15%, transparent);
       border: 1px solid var(--red);
       color: var(--red)
     }
 
     .toast.info {
-      background: rgba(88,166,255,.15);
+      background: color-mix(in srgb, var(--accent) 15%, transparent);
       border: 1px solid var(--accent);
       color: var(--accent)
     }
@@ -756,7 +756,7 @@
     }
     .asset-card.sel {
       border-color: var(--accent);
-      background: rgba(88,166,255,.08)
+      background: color-mix(in srgb, var(--accent) 8%, transparent)
     }
     .asset-card-icon { font-size: 20px; margin-bottom: 4px }
     .asset-card-label { font-size: 12px; font-weight: 600; margin-bottom: 2px }
@@ -771,7 +771,7 @@
       border: 1px solid var(--border); cursor: pointer
     }
     .asset-cat-btn.on {
-      background: rgba(88,166,255,.15); color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent);
       border-color: var(--accent)
     }
     .asset-preview {
@@ -808,9 +808,9 @@
       font-size: 10px;
       padding: 1px 6px;
       border-radius: 8px;
-      background: rgba(63,185,80,.15);
+      background: color-mix(in srgb, var(--green) 15%, transparent);
       color: var(--green);
-      border: 1px solid rgba(63,185,80,.3);
+      border: 1px solid color-mix(in srgb, var(--green) 30%, transparent);
       white-space: nowrap
     }
 

--- a/templates/uns_editor.html
+++ b/templates/uns_editor.html
@@ -704,18 +704,21 @@
     }
 
     .toast.ok {
-      background: var(--green);
-      color: #000
+      background: rgba(63,185,80,.15);
+      border: 1px solid var(--green);
+      color: var(--green)
     }
 
     .toast.err {
-      background: var(--red);
-      color: #fff
+      background: rgba(248,81,73,.15);
+      border: 1px solid var(--red);
+      color: var(--red)
     }
 
     .toast.info {
-      background: var(--accent);
-      color: #000
+      background: rgba(88,166,255,.15);
+      border: 1px solid var(--accent);
+      color: var(--accent)
     }
 
     @keyframes tin {

--- a/templates/uns_live.html
+++ b/templates/uns_live.html
@@ -175,7 +175,7 @@
     }
     .btn:hover { opacity: .85 }
     .btn-primary { background: var(--accent); color: var(--on-accent) }
-    .btn-danger  { background: rgba(248,81,73,.15); color: var(--red); border: 1px solid rgba(248,81,73,.3) }
+    .btn-danger  { background: color-mix(in srgb, var(--red) 15%, transparent); color: var(--red); border: 1px solid color-mix(in srgb, var(--red) 30%, transparent) }
     .btn-row { display: flex; gap: 8px; padding: 0 14px 14px }
 
     /* ── Tree panel ── */
@@ -219,7 +219,7 @@
       transition: background .1s;
     }
     .t-row:hover { background: var(--surface2) }
-    .t-row.flash { background: rgba(88,166,255,.12) }
+    .t-row.flash { background: color-mix(in srgb, var(--accent) 12%, transparent) }
     .t-exp {
       width: 14px; height: 14px;
       display: flex; align-items: center; justify-content: center;

--- a/templates/uns_live.html
+++ b/templates/uns_live.html
@@ -77,15 +77,30 @@
 
     /* ── Layout ── */
     .layout {
-      display: grid;
-      grid-template-columns: 420px 1fr;
+      display: flex;
       height: calc(100vh - 48px - 34px);
       overflow: hidden;
     }
 
+    /* ── Resize handle ── */
+    .resize-handle {
+      width: 4px;
+      background: var(--border);
+      cursor: col-resize;
+      flex-shrink: 0;
+      transition: background .15s;
+    }
+    .resize-handle:hover,
+    .resize-handle.dragging {
+      background: var(--accent);
+    }
+
     /* ── Config panel ── */
     .config-panel {
-      border-right: 1px solid var(--border);
+      width: 360px;
+      min-width: 160px;
+      max-width: 70vw;
+      flex-shrink: 0;
       background: var(--surface);
       display: flex;
       flex-direction: column;
@@ -150,6 +165,8 @@
     .tree-panel {
       display: flex;
       flex-direction: column;
+      flex: 1;
+      min-width: 0;
       overflow: hidden;
     }
     .tree-toolbar {
@@ -359,6 +376,8 @@
     </div>
   </div>
 
+  <div class="resize-handle" id="live-resize"></div>
+
   <!-- Right: live tree -->
   <div class="tree-panel">
     <div class="tree-toolbar">
@@ -528,7 +547,7 @@ function buildNode(key, node, depth, path) {
 
   const row = document.createElement('div');
   row.className = 't-row' + (selected === path ? ' sel' : '');
-  row.style.paddingLeft = (depth * 16 + 6) + 'px';
+  row.style.paddingLeft = (depth * 10 + 6) + 'px';
   row.dataset.path = path;
 
   // Value display
@@ -722,6 +741,40 @@ function loadSettings() {
 
 // Load saved settings on page load
 loadSettings();
+
+// ── Panel resize ───────────────────────────────────────────────────────────────
+(function() {
+  const handle = document.getElementById('live-resize');
+  const panel  = document.querySelector('.config-panel');
+  const KEY    = 'uns-live-config-width';
+  const saved  = localStorage.getItem(KEY);
+  const w = parseInt(saved, 10);
+  if (w > 0) panel.style.width = w + 'px';
+  let dragging = false, x0 = 0, w0 = 0;
+  handle.addEventListener('mousedown', e => {
+    dragging = true; x0 = e.clientX; w0 = panel.offsetWidth;
+    handle.classList.add('dragging');
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    e.preventDefault();
+  });
+  document.addEventListener('mousemove', e => {
+    if (!dragging) return;
+    panel.style.width = Math.max(160, Math.min(w0 + e.clientX - x0, window.innerWidth * 0.7)) + 'px';
+  });
+  document.addEventListener('mouseup', () => {
+    if (!dragging) return;
+    dragging = false;
+    handle.classList.remove('dragging');
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+    localStorage.setItem(KEY, panel.offsetWidth);
+  });
+  handle.addEventListener('dblclick', () => {
+    panel.style.width = '360px';
+    localStorage.removeItem(KEY);
+  });
+})();
 </script>
 </body>
 </html>

--- a/templates/uns_live.html
+++ b/templates/uns_live.html
@@ -21,6 +21,23 @@
       --red:       #f85149;
       --purple:    #a371f7;
       --orange:    #f0883e;
+      --on-accent: #0d1117;
+    }
+    [data-theme="light"] {
+      --bg:        #f6f8fa;
+      --surface:   #ffffff;
+      --surface2:  #f0f2f5;
+      --surface3:  #e8ebef;
+      --border:    #d0d7de;
+      --text:      #1f2328;
+      --muted:     #656d76;
+      --accent:    #0969da;
+      --green:     #1a7f37;
+      --yellow:    #9a6700;
+      --red:       #cf222e;
+      --purple:    #8250df;
+      --orange:    #953800;
+      --on-accent: #ffffff;
     }
 
     html, body {
@@ -157,7 +174,7 @@
       transition: opacity .15s;
     }
     .btn:hover { opacity: .85 }
-    .btn-primary { background: var(--accent); color: #0d1117 }
+    .btn-primary { background: var(--accent); color: var(--on-accent) }
     .btn-danger  { background: rgba(248,81,73,.15); color: var(--red); border: 1px solid rgba(248,81,73,.3) }
     .btn-row { display: flex; gap: 8px; padding: 0 14px 14px }
 
@@ -303,7 +320,12 @@
     ::-webkit-scrollbar { width: 4px; height: 4px }
     ::-webkit-scrollbar-track { background: transparent }
     ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px }
+    .btn-theme{background:var(--surface2);border:1px solid var(--border);color:var(--muted);padding:5px 10px;border-radius:6px;font-size:13px}
+    .btn-theme:hover{border-color:var(--accent);color:var(--accent)}
+    .btn-theme::before{content:'Light'}
+    [data-theme="light"] .btn-theme::before{content:'Dark'}
   </style>
+  <script>(function(){var t=localStorage.getItem('uns-theme')||'dark';document.documentElement.setAttribute('data-theme',t);})();</script>
 </head>
 <body>
 
@@ -314,6 +336,7 @@
     <div class="subtitle">Real-time topic tree via MQTT over WebSocket</div>
   </div>
   <div class="hspace"></div>
+  <button class="btn-theme" onclick="toggleTheme()" title="Toggle light/dark theme"></button>
   <a href="/" style="color:var(--muted);font-size:12px;text-decoration:none;border:1px solid var(--border);padding:5px 10px;border-radius:5px">← Dashboard</a>
   <a href="/uns" style="color:var(--muted);font-size:12px;text-decoration:none;border:1px solid var(--border);padding:5px 10px;border-radius:5px">🌐 Designer</a>
 </header>
@@ -775,6 +798,12 @@ loadSettings();
     localStorage.removeItem(KEY);
   });
 })();
+
+function toggleTheme() {
+  const next = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('uns-theme', next);
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
 UNS Design Studio previously had only a dark theme, which was hard to read in bright environments. This PR adds a full light theme with a
  persistent toggle button in the header of every page.

  What changed
  - "Light" / "Dark" toggle button added to Dashboard, UNS Designer, Live View, and Payload Schemas pages
  - Theme selection persists in localStorage and is restored without flash on page load
  - GitHub-style light palette: white surfaces, dark text, blue accent
  - All hardcoded dark-specific colors fixed:
    - #0d1117 text on accent buttons → var(--on-accent)
    - Dark toast backgrounds → semi-transparent via color-mix()
    - Dark hover/active backgrounds → color-mix() tints derived from CSS vars
    - All rgba(R,G,B,X) tints refactored to color-mix(in srgb, var(--color) X%, transparent) so tints track theme vars automatically