### PR TITLE
feat(viz): visualization canvas, helpers, tests + UNS fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ import os, sys, time, json, socket, threading, subprocess, hashlib, atexit, sign
 from flask import Flask, render_template, jsonify, request
 from json_persistence import load_json, save_json_atomic
 from sim_state_service import get_site_recipes, merge_sim_state_update, sync_sim_state_with_uns
-from uns_tree import enterprise_structure
+from uns_tree import enterprise_structure, resolve_enterprise_root
 
 # ── Adjust path so recipe.py is importable ────────────────────────────────────
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -23,6 +23,7 @@ UNS_CONFIG_FILE      = os.path.join(BASE_DIR, 'uns_config.json')
 SCHEMAS_CONFIG_FILE  = os.path.join(BASE_DIR, 'payload_schemas.json')
 SERVER_CONFIG_FILE   = os.path.join(BASE_DIR, 'server_config.json')
 SIM_STATE_FILE       = os.path.join(BASE_DIR, 'sim_state.json')
+VIZ_CONFIG_FILE      = os.path.join(BASE_DIR, 'visualization.json')
 
 def _json_log(msg: str):
     print(msg, flush=True)
@@ -66,11 +67,11 @@ def _get_namespace_uri() -> str:
 # ── DYNAMIC ENTERPRISE NAME (FIXED) ───────────────────────────────────────────
 def _get_enterprise_name() -> str:
     """Return the root enterprise name from uns_config.json.
-    This is the critical fix that makes any custom namespace root (AcmeEnterprise, MyCompany, etc.)
-    work with the dashboard, polling loop, and OPC-UA client."""
+    Supports both legacy (tree IS enterprise) and wrapper (tree.children[0] is enterprise) layouts."""
     try:
         cfg = load_json(UNS_CONFIG_FILE, {}, logger=_json_log, label='uns_config.json')
-        return cfg.get('tree', {}).get('name', 'GlobalFoodCo')
+        name, _ = resolve_enterprise_root(cfg.get('tree', {}) if isinstance(cfg, dict) else {})
+        return name
     except Exception:
         return 'GlobalFoodCo'
 
@@ -137,6 +138,7 @@ _state = {
     'server_logs': [],
     'opc_connected': False,
     'plant_data':  {},
+    'viz_values':  {},
     # Bridge
     'bridge_proc':  None,
     'bridge_stats': {
@@ -713,9 +715,10 @@ def _poll_loop():
 
             ns_idx = None
             ent = None
+            current_namespace = _get_namespace_uri()
             for attempt in range(12):
                 try:
-                    ns_idx = client.get_namespace_index(NAMESPACE_URI)
+                    ns_idx = client.get_namespace_index(current_namespace)
                 except Exception as e:
                     if "BadNoMatch" in str(e):
                         time.sleep(0.5)
@@ -732,6 +735,8 @@ def _poll_loop():
 
             if ent is None:
                 _state['opc_connected'] = False
+                with _locks['data']:
+                    _state['viz_values'] = {}
                 _log(f"[poll] OPC UA available but root node '{current_enterprise}' not ready yet")
                 try:
                     client.disconnect()
@@ -750,9 +755,12 @@ def _poll_loop():
                 try:
                     with _locks['data']:
                         _state['plant_data'] = _collect_plant_data(ent, ns_idx)
+                        _state['viz_values'] = _collect_viz_values(ent, ns_idx)
                 except Exception as e:
                     _log(f"[poll] Data collection error (triggering reconnect): {e}")
                     _state['opc_connected'] = False
+                    with _locks['data']:
+                        _state['viz_values'] = {}
                     break
                 time.sleep(3)
 
@@ -763,6 +771,8 @@ def _poll_loop():
 
         except Exception as e:
             _state['opc_connected'] = False
+            with _locks['data']:
+                _state['viz_values'] = {}
             err_str = str(e)
             if "10061" in err_str or "ConnectionRefused" in err_str or "Connection refused" in err_str:
                 _log("[poll] OPC UA unavailable: Connection refused - Is the factory server running?")
@@ -783,7 +793,7 @@ def _opc_write(fn):
         enterprise_name = _get_enterprise_name()
         client = Client(_endpoint())
         client.connect()
-        idx  = client.get_namespace_index(NAMESPACE_URI)
+        idx  = client.get_namespace_index(_get_namespace_uri())
         root = client.get_root_node()
         ent  = root.get_child(["0:Objects", f"{idx}:{enterprise_name}"])
         result = fn(client, idx, ent)
@@ -1321,6 +1331,76 @@ def api_schemas_save():
     if not save_json_atomic(SCHEMAS_CONFIG_FILE, data, ensure_ascii=False, logger=_json_log, label='payload_schemas.json'):
         return jsonify({'ok': False, 'error': 'Could not write payload schemas'}), 500
     return jsonify({'ok': True})
+
+# ── Visualization (SCADA mimic) ───────────────────────────────────────────────
+# Pure logic lives in viz_service.py; this module only holds the Flask routes
+# and the OPC traversal callable used by the poll loop.
+
+import viz_service
+
+def _suggest_kind(name): return viz_service.suggest_kind(name)
+def _load_viz_cfg(): return viz_service.load_viz_cfg(VIZ_CONFIG_FILE)
+def _save_viz_cfg(data): viz_service.save_viz_cfg(VIZ_CONFIG_FILE, data)
+def _walk_viz_entities(): return viz_service.walk_entities(UNS_CONFIG_FILE)
+def _viz_resolve_tag_path(entity_id, tag_name):
+    return viz_service.resolve_tag_path(UNS_CONFIG_FILE, entity_id, tag_name)
+
+def _collect_viz_values(ent, idx):
+    """Bridge viz_service.collect_values to a live OPC client (poll loop only)."""
+    def read(path):
+        try:
+            n = ent
+            for part in path:
+                n = n.get_child([f"{idx}:{part}"])
+            return n.get_value()
+        except Exception:
+            return None
+    return viz_service.collect_values(
+        _load_viz_cfg().get('gauges', []),
+        _viz_resolve_tag_path,
+        read,
+    )
+
+@app.route('/viz')
+def viz_page():
+    return render_template('visualization.html')
+
+@app.route('/api/viz/config', methods=['GET'])
+def api_viz_get():
+    return jsonify(_load_viz_cfg())
+
+@app.route('/api/viz/config', methods=['POST'])
+def api_viz_save():
+    data = request.json or {}
+    data.setdefault('version', 1)
+    data['lastModified'] = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+    _save_viz_cfg(data)
+    return jsonify({'ok': True})
+
+@app.route('/api/viz/entities', methods=['GET'])
+def api_viz_entities():
+    mapped   = _load_viz_cfg().get('entities', {})
+    entities = _walk_viz_entities()
+    for e in entities:
+        cur = mapped.get(e['id'], {})
+        e['suggestion'] = _suggest_kind(e['name'])
+        e['kind']       = cur.get('kind') or e['suggestion']
+        e['mapped']     = bool(cur.get('kind'))
+    return jsonify({'kinds': viz_service.EQUIPMENT_KINDS, 'entities': entities})
+
+@app.route('/api/viz/values', methods=['GET'])
+def api_viz_values():
+    with _locks['data']:
+        values = dict(_state.get('viz_values') or {})
+    return jsonify({
+        'values':    values,
+        'opc_ready': bool(_state.get('opc_connected')),
+        'ts':        time.time(),
+    })
+
+@app.route('/api/viz/tags/<path:entity_id>', methods=['GET'])
+def api_viz_tags(entity_id):
+    return jsonify({'tags': viz_service.entity_tags(UNS_CONFIG_FILE, entity_id)})
 
 # ── Entry point ────────────────────────────────────────────────────────────────
 if __name__ == '__main__':

--- a/docs/UNS-CONTEXT.md
+++ b/docs/UNS-CONTEXT.md
@@ -1,0 +1,161 @@
+# UNS Design Studio — Context & Industrial IoT Landscape
+
+This document explains where this project sits in the broader industrial IoT
+architecture conversation: what the simulator does, who uses it, and how the
+"Unified Namespace" school of thought relates to alternative approaches.
+
+---
+
+## 1. What this project is
+
+A **UNS (Unified Namespace) sandbox** — a self-contained simulator that lets
+practitioners design, demo, and prototype industrial data architectures without
+needing real PLCs, factories, or vendor-specific platforms.
+
+It bundles:
+
+- **UNS designer** — visual ISA-95 tree editor (Enterprise → BU → Site → Area →
+  WorkCenter → WorkUnit → Tags).
+- **OPC-UA server** — dynamic address space built from the designed tree.
+- **Stateful simulation engine** — per-plant state machine (Running / Fault /
+  Recovery / Stopped) with profile-driven tag values, recipe overrides, and
+  realistic correlations (vibration ↔ fault risk, OEE = avail × perf × qual,
+  rate-based accumulators).
+- **MQTT / NATS bridge** — publishes OPC-UA values to topic trees with
+  configurable separators, prefixes, and payload schemas.
+- **Asset library** — reusable equipment templates with pre-defined tag sets.
+- **Anomaly injection** — TCP override channel for testing alarm rules and
+  anomaly detectors against known-bad data.
+- **Web dashboard** — Flask-based control plane for plants, recipes, and the
+  factory subprocess lifecycle.
+
+---
+
+## 2. Use cases
+
+| Audience | Typical use |
+|---|---|
+| **SI / consultants** | UNS proofs-of-concept and customer demos without a physical line in the room. |
+| **Vendors** | Integration testing for UNS-aware tools (Ignition, Grafana, HighByte, MQTT Explorer, historians). |
+| **Educators** | Teach ISA-95 modeling, OPC-UA browsing, MQTT topic design, and payload schema concepts on synthetic data that behaves like a plant. |
+| **Architects** | Iterate on naming conventions, separators, payload schemas, and asset library structures cheaply before locking decisions. |
+| **Data / ML teams** | Build dashboards, anomaly models, and condition-based-maintenance triggers against the simulator and swap to a real OPC server later. |
+| **MES / scheduling demos** | Show recipe / changeover behavior without rewiring a real production line. |
+
+It is **not** a production tool. Its value is in being throw-away realistic
+during the design and validation phases of an OT modernization project.
+
+---
+
+## 3. The UNS school of thought
+
+The simulator's worldview tracks Walker Reynolds / 4.0 Solutions, who
+popularized **Unified Namespace** as a design pattern:
+
+- **Single source of truth** — one namespace, every system publishes to / reads
+  from it.
+- **MQTT-centric, event-driven** — report-by-exception, not polling.
+- **Edge-first** — context produced where data is born, not in the cloud.
+- **ISA-95 hierarchy** — flattened into MQTT topic paths.
+- **Decoupled producers / consumers** — broker is the integration boundary.
+
+This framing landed broadly with OT audiences who had been buried in
+vendor-specific stacks, and it now drives a large fraction of the modern
+"industrial DataOps" conversation.
+
+---
+
+## 4. Alternative / adjacent schools
+
+UNS is one architecture among several. Production stacks usually blend a few.
+
+### 4.1 ISA-95 / B2MML (the formal spec)
+Original standard the UNS borrows its hierarchy from. XML / database-centric,
+MES-oriented, top-down governance. UNS is its scrappier MQTT cousin.
+
+### 4.2 Sparkplug B (Cirrus Link / Eclipse Tahu)
+MQTT spec for industrial: stateful sessions (birth / death messages), strict
+topic structure, defined payload format. Many UNS implementations use Sparkplug
+under the hood, but a "Sparkplug-only" camp argues the ISA-95 framing is
+unnecessary — the spec is enough. Inductive Automation pushes this hardest.
+
+### 4.3 OPC UA purists
+"Address space + Companion Specs (PA-DIM, VDMA, AutoID) is the model. MQTT is
+unnecessary middleware." The OPC Foundation's line. UA-over-MQTT (UA PubSub) is
+their answer to UNS-style pub/sub.
+
+### 4.4 Industrial DataOps (HighByte, Litmus, Cogent)
+Focus is **pipelines, transformations, governance, lineage**. UNS is one of
+many possible sinks. Treats data as an engineered artifact rather than a
+pub/sub fabric.
+
+### 4.5 Event streaming (Confluent / Kafka, Solace event mesh)
+"UNS but log-based" — replayable, partitioned, schema registry, designed for
+analytics-heavy and high-throughput workloads. NATS sits on the lighter,
+edge-friendly end of this same family.
+
+### 4.6 Historian-first (Aveva PI, InfluxDB, TDengine, TimescaleDB)
+The historian itself is the source of truth; a UNS layer is optional veneer.
+This was the OT default before MQTT-style pub/sub gained traction.
+
+### 4.7 Asset Administration Shell (AAS) / Manufacturing-X / Catena-X
+European Industrie 4.0 / Plattform i40 effort. Digital-twin shells, semantic
+models, supply-chain federation. Government-backed in Germany / EU; strong in
+automotive supply chains.
+
+### 4.8 ISA-88 batch control
+Recipe and batch-state focus. OPC UA has a batch companion spec. Heavily used
+in pharma and food & beverage where the recipe is the primary modeling concern.
+
+### 4.9 MTConnect
+Discrete manufacturing (CNC, machine tools). XML over HTTP, not pub/sub. Niche
+but dominant in its segment.
+
+---
+
+## 5. How they coexist in practice
+
+A typical modern OT stack pulls from several of the above:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Consumers: dashboards, MES, ML, supply-chain partners  │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────┐
+│  UNS layer (MQTT + ISA-95 topics)  ← Walker / 4.0 frame │
+└──────────┬──────────────────────────┬───────────────────┘
+           │                          │
+┌──────────▼──────────┐    ┌──────────▼───────────────┐
+│  Event log (Kafka)  │    │  Historian (PI / Influx) │
+│  for analytics      │    │  for storage & queries   │
+└──────────┬──────────┘    └──────────┬───────────────┘
+           │                          │
+┌──────────▼──────────────────────────▼───────────────┐
+│  Edge: OPC UA servers, Sparkplug B, MTConnect, …    │
+└──────────────────────┬──────────────────────────────┘
+                       │
+                  ┌────▼────┐
+                  │  PLCs   │
+                  └─────────┘
+```
+
+The UNS layer is the **integration bus**; the other layers handle storage,
+analytics, federation, and connectivity. Walker Reynolds' contribution was
+popularizing the *single-namespace + edge-driven + report-by-exception* mantra
+to a broad OT audience — not inventing every component beneath it.
+
+---
+
+## 6. Where this simulator fits the map
+
+UNS Design Studio is opinionated toward the **MQTT + ISA-95 + payload-schema**
+school. It is most directly useful for:
+
+- Designing what the topic tree and payload schemas *should* look like.
+- Validating downstream consumers against realistic synthetic data.
+- Teaching the conceptual model.
+
+It does **not** ship Sparkplug B, Kafka, AAS, or historian integration out of
+the box. Those would be additions on top of (or replacements for) the bridge
+layer.

--- a/factory.py
+++ b/factory.py
@@ -22,6 +22,7 @@ import time
 import datetime
 from opcua import Server, ua
 from json_persistence import load_json, load_json_or_raise
+from uns_tree import resolve_enterprise_root
 
 logging.getLogger('opcua').setLevel(logging.ERROR)
 logging.basicConfig(level=logging.WARN)
@@ -52,12 +53,24 @@ def _resolve_endpoint_host() -> str:
     return '127.0.0.1'
 
 SERVER_ENDPOINT = f"opc.tcp://{_resolve_endpoint_host()}:{_OPC_PORT}/freeopcua/server/"
-NAMESPACE_URI   = "http://VirtualUNS.com/uns"
+NAMESPACE_URI_DEFAULT = "http://VirtualUNS.com/uns"
 TCP_SERVER_IP   = "0.0.0.0"
 TCP_SERVER_PORT = _TCP_PORT
 
 stop_flag         = False
 anomaly_overrides = {}
+
+def _get_namespace_uri() -> str:
+    try:
+        path = _os.path.join(BASE_DIR, 'uns_config.json')
+        cfg = load_json(path, {}, logger=_json_log, label='uns_config.json')
+        if isinstance(cfg, dict):
+            return cfg.get('namespaceUri') or NAMESPACE_URI_DEFAULT
+    except Exception:
+        pass
+    return NAMESPACE_URI_DEFAULT
+
+NAMESPACE_URI = _get_namespace_uri()
 
 # ================================================================
 # DYNAMIC ENTERPRISE NAME (FIXED — supports any root name from UNS Designer)
@@ -67,7 +80,8 @@ def _get_enterprise_name() -> str:
     try:
         path = _os.path.join(BASE_DIR, 'uns_config.json')
         cfg = load_json(path, {}, logger=_json_log, label='uns_config.json')
-        return cfg.get('tree', {}).get('name', 'GlobalFoodCo')
+        name, _ = resolve_enterprise_root(cfg.get('tree', {}) if isinstance(cfg, dict) else {})
+        return name
     except Exception:
         return 'GlobalFoodCo'
 
@@ -533,6 +547,8 @@ def _create_dynamic_address_space(server, idx, enterprise_obj):
     variables       = {}
     anomaly_key_map = {}
 
+    _, enterprise_node = resolve_enterprise_root(tree)
+
     canonical = {}
     def _collect_canonical(node):
         name = node.get('name', '')
@@ -541,7 +557,7 @@ def _create_dynamic_address_space(server, idx, enterprise_obj):
             canonical[name] = tags
         for child in node.get('children', []):
             _collect_canonical(child)
-    _collect_canonical(tree)
+    _collect_canonical(enterprise_node)
 
     def _walk(node, uns_parts, opc_parts, area_opc_parts, plant_key):
         ntype    = node.get('type', '')
@@ -579,15 +595,16 @@ def _create_dynamic_address_space(server, idx, enterprise_obj):
                 except Exception:
                     current = current.add_object(idx, part)
 
-            if data_type == 'Float':
+            dt = (data_type or 'Float').strip()
+            if dt in ('Float', 'Double', 'Real'):
                 default, vt = 0.0,   ua.VariantType.Double
-            elif data_type == 'Int':
+            elif dt in ('Int', 'Int16', 'Int32', 'Int64', 'Integer', 'UInt16', 'UInt32', 'UInt64'):
                 default, vt = 0,     ua.VariantType.Int64
-            elif data_type == 'Bool':
+            elif dt in ('Bool', 'Boolean'):
                 default, vt = False, ua.VariantType.Boolean
-            elif data_type == 'String':
+            elif dt in ('String', 'Str'):
                 default, vt = "",    ua.VariantType.String
-            elif data_type == 'DateTime':
+            elif dt in ('DateTime', 'Timestamp'):
                 default = datetime.datetime.now(datetime.timezone.utc)
                 vt      = ua.VariantType.DateTime
             else:
@@ -608,7 +625,7 @@ def _create_dynamic_address_space(server, idx, enterprise_obj):
         for child in node.get('children', []):
             _walk(child, uns_parts + [name], new_opc, new_area, new_plant_key)
 
-    for child in tree.get('children', []):
+    for child in enterprise_node.get('children', []):
         _walk(child, [], [], [], None)
 
     print(f"[factory] Dynamic address space ready — {len(variables)} tags")

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "uns-design-studio-frontend-tests",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Node test runner for browser-side pure helpers (no deps).",
+  "scripts": {
+    "test": "node --test \"tests-js/**/*.test.js\""
+  }
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -ra --strict-markers

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0

--- a/static/css/command_center_theme.css
+++ b/static/css/command_center_theme.css
@@ -62,6 +62,9 @@ body::before {
   flex-direction: column;
   padding: 18px 12px;
   color: #ffffff;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .cc-sidebar-brand {
@@ -250,6 +253,9 @@ textarea {
   color: var(--text) !important;
   border: 1px solid #d1d5db !important;
   box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.04);
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 input:focus,

--- a/static/js/uns_editor.js
+++ b/static/js/uns_editor.js
@@ -840,6 +840,35 @@ function doImport() {
     if (merge && uns.tree && uns.tree.children) {
       const incoming = d.tree.children || [];
       if (!incoming.length) throw new Error('Nothing to merge — imported tree has no children');
+
+      const incomingEnt = d.tree;
+      const droppedMeta = [];
+      if (incomingEnt.type === 'enterprise' && incomingEnt.name && incomingEnt.name !== uns.tree.name) {
+        droppedMeta.push(`enterprise name "${incomingEnt.name}"`);
+      }
+      if (d.namespaceUri && d.namespaceUri !== (uns.namespaceUri || '')) {
+        droppedMeta.push(`namespaceUri "${d.namespaceUri}"`);
+      }
+      if (d.description && d.description !== (uns.description || '')) {
+        droppedMeta.push('top-level description');
+      }
+
+      const existingNames = new Set((uns.tree.children || []).map(c => c.name));
+      const collisions = incoming.map(c => c.name).filter(n => existingNames.has(n));
+
+      const warnings = [];
+      if (droppedMeta.length) {
+        warnings.push(`Imported wrapper will be DISCARDED — only its child nodes are merged.\nDropped: ${droppedMeta.join(', ')}.`);
+      }
+      if (collisions.length) {
+        warnings.push(`Name collision — duplicate top-level nodes will be created: ${collisions.join(', ')}.`);
+      }
+
+      if (warnings.length) {
+        const msg = warnings.join('\n\n') + '\n\nProceed with merge?';
+        if (!confirm(msg)) return;
+      }
+
       uns.tree.children = uns.tree.children.concat(incoming);
       toast(`Merged ${incoming.length} node(s) into existing tree`, 'ok');
     } else {

--- a/static/js/viz_math.js
+++ b/static/js/viz_math.js
@@ -1,0 +1,140 @@
+/**
+ * Pure math/layout helpers for the visualization canvas.
+ *
+ * UMD-ish: exposes window.VizMath in the browser AND module.exports for Node.
+ * No DOM access, no globals — safe to unit-test with node:test.
+ */
+(function (global, factory) {
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory();
+  } else {
+    global.VizMath = factory();
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  function widgetSize(widget) {
+    switch (widget) {
+      case 'gauge':   return { w: 70, h: 60 };
+      case 'bar':     return { w: 90, h: 48 };
+      case 'led':     return { w: 50, h: 32 };
+      case 'fill':    return { w: 36, h: 56 };
+      case 'numeric':
+      default:        return { w: 80, h: 32 };
+    }
+  }
+
+  function clamp01(v) { return v < 0 ? 0 : (v > 1 ? 1 : v); }
+
+  function fmtNum(v, decimals) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) return String(v);
+    return v.toFixed(decimals || 0);
+  }
+
+  /**
+   * Place a gauge near its parent node:
+   *  - if explicit layout → use it
+   *  - else stack siblings (same entity, no explicit layout) vertically
+   *    to the right of the node, centered on node.y.
+   */
+  function gaugePosition(g, gNodeMap, allGauges) {
+    if (g.layout && Number.isFinite(g.layout.x) && Number.isFinite(g.layout.y)) {
+      return { x: g.layout.x, y: g.layout.y };
+    }
+    const sz = widgetSize(g.widget);
+    const n  = gNodeMap.get(g.entity);
+    if (!n) return { x: 20, y: 20 };
+
+    const siblings = (allGauges || []).filter(x =>
+      x.entity === g.entity && (!x.layout || !Number.isFinite(x.layout.x))
+    );
+    const idx = Math.max(0, siblings.indexOf(g));
+    const gap = 6;
+
+    let totalH = 0;
+    for (const s of siblings) totalH += widgetSize(s.widget).h + gap;
+    totalH -= gap;
+    let yOff = -totalH / 2;
+    for (let i = 0; i < idx; i++) yOff += widgetSize(siblings[i].widget).h + gap;
+    return { x: n.x + n.width / 2 + 12, y: n.y + yOff };
+  }
+
+  /**
+   * Endpoints of a semicircle arc dome (opens upward) on screen.
+   * frac is the filled portion ∈ [0,1].
+   * Returns {x0,y0,x1,y1}; (x0,y0)=left baseline, (x1,y1)=tip.
+   */
+  function arcEndpoints(cx, cy, r, frac) {
+    const a0 = Math.PI;
+    const a1 = a0 - Math.PI * Math.max(0.0001, frac);
+    return {
+      x0: cx + r * Math.cos(a0),
+      y0: cy - r * Math.sin(a0),
+      x1: cx + r * Math.cos(a1),
+      y1: cy - r * Math.sin(a1),
+    };
+  }
+
+  /**
+   * Bounding box for a set of dagre-positioned nodes plus gauges.
+   * nodes: iterable of { x, y, width, height }.
+   * gauges + getPos(g) → {x,y} (top-left of widget rect).
+   * Returns { minX, minY, maxX, maxY, w, h } with default min size 400×300.
+   */
+  function computeBbox(nodes, gauges, getPos) {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const n of nodes) {
+      minX = Math.min(minX, n.x - n.width  / 2 - 30);
+      minY = Math.min(minY, n.y - n.height / 2 - 30);
+      maxX = Math.max(maxX, n.x + n.width  / 2 + 30);
+      maxY = Math.max(maxY, n.y + n.height / 2 + 30);
+    }
+    for (const gg of (gauges || [])) {
+      const sz  = widgetSize(gg.widget);
+      const pos = getPos(gg);
+      if (!pos) continue;
+      minX = Math.min(minX, pos.x - 12);
+      minY = Math.min(minY, pos.y - 12);
+      maxX = Math.max(maxX, pos.x + sz.w + 12);
+      maxY = Math.max(maxY, pos.y + sz.h + 12);
+    }
+    if (!Number.isFinite(minX)) { minX = 0; minY = 0; maxX = 400; maxY = 300; }
+    const w = Math.max(400, maxX - minX);
+    const h = Math.max(300, maxY - minY);
+    return { minX, minY, maxX, maxY, w, h };
+  }
+
+  /**
+   * Map an LED gauge value to its visual fill/stroke pair.
+   * null/undefined → "no data" (surface3 + border).
+   * Truthy (excluding 'False' / 0) → green; else red.
+   */
+  function ledColors(value) {
+    if (value === null || value === undefined) {
+      return { fill: 'var(--surface3)', stroke: 'var(--border)' };
+    }
+    const on = !!value && value !== 'False' && value !== 0;
+    return on
+      ? { fill: 'var(--green)', stroke: 'var(--green)' }
+      : { fill: 'var(--red)',   stroke: 'var(--red)' };
+  }
+
+  /**
+   * Filled fraction of a gauge for a given value, min, max ∈ [0,1].
+   */
+  function gaugeFraction(value, min, max) {
+    if (value === null || value === undefined) return 0;
+    const v = Number(value);
+    if (!Number.isFinite(v)) return 0;
+    return clamp01((v - min) / Math.max(0.0001, max - min));
+  }
+
+  return {
+    widgetSize,
+    clamp01,
+    fmtNum,
+    gaugePosition,
+    arcEndpoints,
+    computeBbox,
+    ledColors,
+    gaugeFraction,
+  };
+});

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -29,6 +29,10 @@
             <span class="cc-nav-icon">↯</span>
             <span>Live UNS View</span>
         </a>
+        <a class="cc-nav-link" href="/viz">
+            <span class="cc-nav-icon">◧</span>
+            <span>Visualization</span>
+        </a>
         <a class="cc-nav-link" href="/settings">
             <span class="cc-nav-icon">▤</span>
             <span>Settings</span>

--- a/templates/visualization.html
+++ b/templates/visualization.html
@@ -1,0 +1,1834 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>UNS Design Studio – Visualization</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0d1117; --surface:#161b22; --surface2:#1c2128; --surface3:#21262d;
+  --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff;
+  --green:#3fb950; --red:#f85149; --yellow:#e3b341; --orange:#d29922; --purple:#a371f7;
+  --radius:8px; --shadow:0 4px 16px rgba(0,0,0,.5); --on-accent:#0d1117;
+}
+[data-theme="light"]{
+  --bg:#f6f8fa; --surface:#ffffff; --surface2:#f0f2f5; --surface3:#e8ebef;
+  --border:#d0d7de; --text:#1f2328; --muted:#656d76; --accent:#0969da;
+  --green:#1a7f37; --red:#cf222e; --yellow:#9a6700; --orange:#953800; --purple:#8250df;
+  --shadow:0 4px 16px rgba(0,0,0,.1); --on-accent:#ffffff;
+}
+html,body{height:100%;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;
+  background:var(--bg);color:var(--text);font-size:14px;line-height:1.5}
+button{cursor:pointer;border:none;border-radius:6px;font:inherit;transition:opacity .15s,transform .1s}
+button:hover{opacity:.85}
+button:active{transform:scale(.97)}
+select,input{font:inherit;background:var(--surface3);color:var(--text);
+  border:1px solid var(--border);border-radius:6px;padding:6px 10px;outline:none}
+select:focus,input:focus{border-color:var(--accent)}
+body{display:flex;flex-direction:column;min-height:100vh}
+/* edit mode locks viewport so the canvas takes the full screen */
+body.canvas-edit{height:100vh;overflow:hidden;min-height:0}
+
+.app-header{background:var(--surface);border-bottom:1px solid var(--border);
+  padding:0 20px;height:56px;display:flex;align-items:center;gap:16px;flex-shrink:0;
+  position:sticky;top:0;z-index:100}
+.header-brand{display:flex;align-items:center;gap:10px}
+.header-brand .logo{font-size:24px}
+.header-brand h1{font-size:15px;font-weight:700;letter-spacing:.3px;white-space:nowrap}
+.header-brand .sub{font-size:11px;color:var(--muted);display:block;letter-spacing:.5px;text-transform:uppercase}
+.header-right{margin-left:auto;display:flex;align-items:center;gap:8px}
+.header-right a, .header-right button{
+  background:var(--surface3);color:var(--text);border:1px solid var(--border);
+  padding:6px 12px;border-radius:6px;font-size:13px;text-decoration:none;white-space:nowrap}
+.header-right a.active{border-color:var(--accent);color:var(--accent)}
+
+.tabs{background:var(--surface2);border-bottom:1px solid var(--border);
+  padding:0 20px;display:flex;align-items:center;gap:4px;flex-shrink:0}
+.tab{padding:12px 16px;border-bottom:2px solid transparent;color:var(--muted);
+  font-size:13px;font-weight:600;cursor:pointer;background:none;border-radius:0}
+.tab:hover{color:var(--text)}
+.tab.active{color:var(--accent);border-bottom-color:var(--accent)}
+
+.view{flex:1;display:none;overflow:hidden}
+.view.active{display:flex}
+
+/* ── Wizard ─────────────────────────────────────────────────────────────── */
+#viewWizard{flex-direction:column;padding:20px;overflow:auto}
+.wizard-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;gap:12px}
+.wizard-head h2{font-size:18px;font-weight:600}
+.wizard-head .sub{color:var(--muted);font-size:13px;margin-top:2px}
+.wizard-actions{display:flex;gap:8px}
+.btn-primary{background:var(--accent);color:var(--on-accent);padding:8px 16px;font-weight:600;font-size:13px}
+.btn-secondary{background:var(--surface3);color:var(--text);border:1px solid var(--border);padding:8px 16px;font-size:13px}
+
+.entity-table{width:100%;border-collapse:collapse;background:var(--surface);
+  border:1px solid var(--border);border-radius:8px;overflow:hidden}
+.entity-table th{background:var(--surface2);padding:10px 14px;text-align:left;
+  font-size:12px;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:.5px;
+  border-bottom:1px solid var(--border)}
+.entity-table td{padding:10px 14px;border-bottom:1px solid var(--border);font-size:13px;vertical-align:middle}
+.entity-table tr:last-child td{border-bottom:none}
+.entity-table tr:hover{background:var(--surface2)}
+.entity-name{font-weight:600}
+.entity-path{color:var(--muted);font-size:11px;font-family:ui-monospace,monospace;margin-top:2px}
+.entity-type-badge{display:inline-block;padding:2px 8px;border-radius:4px;font-size:11px;
+  font-weight:600;text-transform:uppercase;letter-spacing:.5px;
+  background:var(--surface3);color:var(--muted)}
+.entity-type-badge.site{background:color-mix(in srgb,var(--purple) 20%,transparent);color:var(--purple)}
+.entity-type-badge.area{background:color-mix(in srgb,var(--accent) 20%,transparent);color:var(--accent)}
+.entity-type-badge.workCenter{background:color-mix(in srgb,var(--yellow) 20%,transparent);color:var(--yellow)}
+.entity-type-badge.workUnit{background:color-mix(in srgb,var(--green) 20%,transparent);color:var(--green)}
+.kind-cell{display:flex;align-items:center;gap:8px}
+.kind-preview{width:32px;height:32px;flex-shrink:0;background:var(--surface3);
+  border:1px solid var(--border);border-radius:4px;padding:3px;display:flex;align-items:center;justify-content:center}
+.kind-preview svg{width:100%;height:100%}
+.suggestion-tag{font-size:10px;color:var(--muted);font-style:italic}
+
+.factory-group{background:var(--surface);border:1px solid var(--border);border-radius:8px;
+  margin-bottom:12px;overflow:hidden}
+.factory-group[open]{box-shadow:var(--shadow)}
+.factory-head{background:var(--surface2);padding:12px 16px;cursor:pointer;display:flex;
+  align-items:center;gap:12px;font-size:13px;list-style:none;user-select:none}
+.factory-head::-webkit-details-marker{display:none}
+.factory-head::before{content:'▶';font-size:10px;color:var(--muted);transition:transform .15s}
+.factory-group[open] .factory-head::before{transform:rotate(90deg)}
+.factory-head:hover{background:var(--surface3)}
+.factory-name{font-weight:700;font-size:14px}
+.factory-path{color:var(--muted);font-size:11px;font-family:ui-monospace,monospace}
+.factory-stats{margin-left:auto;color:var(--muted);font-size:12px}
+.factory-group .entity-table{border:none;border-radius:0}
+
+.empty-state{text-align:center;padding:60px 20px;color:var(--muted)}
+.empty-state h3{margin-bottom:8px}
+
+/* ── Canvas ─────────────────────────────────────────────────────────────── */
+#viewCanvas{flex-direction:column}
+/* in view mode, the canvas tab grows with its content so the page can scroll
+   naturally; in edit mode (body.canvas-edit) it fills the locked viewport */
+body:not(.canvas-edit) #viewCanvas{flex:0 0 auto;overflow:visible}
+.canvas-toolbar{background:var(--surface);border-bottom:1px solid var(--border);
+  padding:8px 14px;display:flex;align-items:center;gap:10px;flex-shrink:0;font-size:12px}
+.canvas-toolbar label{color:var(--muted);font-size:12px;display:flex;align-items:center;gap:6px}
+.canvas-toolbar select{padding:4px 8px;font-size:12px}
+/* host shrinks to content in view mode; expands to fill in edit mode */
+.canvas-host{overflow:auto;background:var(--bg);position:relative}
+body.canvas-edit .canvas-host{flex:1;min-height:0}
+.canvas-host svg.scada{display:block;background:
+  radial-gradient(var(--surface2) 1px, transparent 1px) 0 0/16px 16px,
+  var(--bg)}
+
+.legend{position:absolute;top:12px;right:12px;background:var(--surface);
+  border:1px solid var(--border);border-radius:8px;padding:10px 12px;font-size:11px;
+  display:flex;flex-direction:column;gap:4px;box-shadow:var(--shadow)}
+.legend-row{display:flex;align-items:center;gap:6px}
+.legend-dot{width:10px;height:10px;border-radius:2px}
+.legend-section{font-size:10px;font-weight:700;color:var(--muted);text-transform:uppercase;
+  letter-spacing:.5px;margin-top:2px}
+.legend-section:first-child{margin-top:0}
+.legend-dot.running{background:var(--green)}
+.legend-dot.fault{background:var(--red)}
+.legend-dot.stopped{background:var(--muted)}
+.legend-dot.neutral{background:var(--surface3);border:1px solid var(--border)}
+.legend-dot.led-on{background:var(--green);border-radius:50%}
+.legend-dot.led-off{background:var(--red);border-radius:50%}
+
+/* ── Edit mode ──────────────────────────────────────────────────────────── */
+.tool-btn{padding:5px 10px;font-size:12px;background:var(--surface2);
+  color:var(--text);border:1px solid var(--border);border-radius:6px;cursor:pointer}
+.tool-btn:hover{border-color:var(--accent);color:var(--accent)}
+.tool-btn.active{background:var(--accent);color:var(--on-accent);border-color:var(--accent)}
+.tool-btn[disabled]{opacity:.4;pointer-events:none}
+.tool-divider{width:1px;height:22px;background:var(--border);margin:0 4px}
+.mode-badge{padding:3px 8px;border-radius:4px;font-size:11px;font-weight:600;
+  text-transform:uppercase;letter-spacing:.5px}
+.mode-badge.view{background:var(--surface3);color:var(--muted)}
+.mode-badge.edit{background:color-mix(in srgb,var(--yellow) 25%,transparent);color:var(--yellow)}
+
+svg.scada .viz-node{cursor:default}
+svg.scada.edit .viz-node{cursor:grab}
+svg.scada.edit .viz-node.dragging{cursor:grabbing}
+svg.scada.edit .viz-node:hover rect{stroke-width:3}
+svg.scada .viz-node.selected rect{stroke:var(--yellow);stroke-width:3;
+  filter:drop-shadow(0 0 6px color-mix(in srgb,var(--yellow) 50%,transparent))}
+svg.scada .viz-node.link-source rect{stroke:var(--accent);stroke-width:3;
+  stroke-dasharray:4 3}
+
+svg.scada .viz-link{cursor:default;fill:none}
+svg.scada.edit .viz-link{cursor:pointer}
+svg.scada.edit .viz-link:hover{stroke:var(--accent);stroke-width:3}
+svg.scada .viz-link.selected{stroke:var(--yellow);stroke-width:3}
+svg.scada .viz-link.parent{stroke:var(--border);stroke-width:1.5;stroke-dasharray:4 3}
+svg.scada .viz-link.user{stroke:var(--accent);stroke-width:2}
+svg.scada .viz-link.user.pipe{stroke:var(--purple);stroke-width:3}
+
+svg.scada .ghost-link{stroke:var(--accent);stroke-width:2;
+  stroke-dasharray:4 3;fill:none;pointer-events:none;opacity:.7}
+
+/* ── Gauges (widgets on canvas) ─────────────────────────────────────────── */
+svg.scada .viz-gauge{cursor:default}
+svg.scada.edit .viz-gauge{cursor:grab}
+svg.scada.edit .viz-gauge.dragging{cursor:grabbing}
+svg.scada .viz-gauge.selected .gauge-bg{stroke:var(--yellow);stroke-width:2}
+svg.scada.edit .viz-gauge:hover .gauge-bg{stroke:var(--accent);stroke-width:2}
+svg.scada .gauge-bg{fill:var(--surface);stroke:var(--border);stroke-width:1}
+svg.scada .gauge-label{font-size:9px;fill:var(--muted);font-family:system-ui,sans-serif}
+svg.scada .gauge-value{font-size:14px;fill:var(--text);font-weight:700;font-family:ui-monospace,monospace}
+svg.scada .gauge-unit{font-size:8px;fill:var(--muted)}
+svg.scada .gauge-arc-bg{stroke:var(--border);fill:none;opacity:.9}
+svg.scada .gauge-arc-fg{stroke:var(--accent);fill:none;transition:stroke-dasharray .3s}
+[data-theme="light"] svg.scada .gauge-arc-bg{stroke:var(--muted);opacity:.5}
+svg.scada .gauge-bar-bg{fill:var(--surface3)}
+svg.scada .gauge-bar-fg{fill:var(--accent);transition:width .3s}
+svg.scada .gauge-led{stroke-width:2}
+svg.scada .gauge-fill-bg{fill:var(--surface3);stroke:var(--border);stroke-width:1}
+svg.scada .gauge-fill-fg{fill:var(--accent);transition:height .3s,y .3s}
+
+/* anim: pipe flow */
+@keyframes pipeFlow { from { stroke-dashoffset: 0 } to { stroke-dashoffset: -16 } }
+svg.scada .viz-link.user.pipe.flowing{stroke-dasharray:8 8;animation:pipeFlow 1s linear infinite}
+
+/* anim: motor/pump rotation */
+@keyframes spin { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }
+svg.scada .viz-node.spinning use{transform-box:fill-box;transform-origin:center;animation:spin 2s linear infinite}
+
+/* anim: fault flash */
+@keyframes faultFlash { 0%,100% { opacity:1 } 50% { opacity:.3 } }
+svg.scada .viz-node.fault rect{animation:faultFlash 1s ease-in-out infinite}
+
+/* ── Modal ──────────────────────────────────────────────────────────────── */
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:998;
+  display:flex;align-items:center;justify-content:center}
+.modal{background:var(--surface);border:1px solid var(--border);border-radius:8px;
+  width:440px;max-width:95vw;box-shadow:var(--shadow);overflow:hidden}
+.modal-head{padding:14px 18px;border-bottom:1px solid var(--border);
+  display:flex;align-items:center;justify-content:space-between;font-weight:600;font-size:14px}
+.modal-body{padding:16px 18px;display:flex;flex-direction:column;gap:12px}
+.modal-foot{padding:12px 18px;border-top:1px solid var(--border);
+  display:flex;justify-content:flex-end;gap:8px}
+.modal label{display:flex;flex-direction:column;gap:4px;font-size:12px;color:var(--muted)}
+.modal label input,.modal label select{font-size:13px;width:100%}
+.modal-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px 12px}
+.modal-close{background:none;border:none;color:var(--muted);font-size:18px;cursor:pointer;line-height:1}
+
+/* ── Toasts ─────────────────────────────────────────────────────────────── */
+#toasts{position:fixed;bottom:20px;right:20px;display:flex;flex-direction:column;gap:8px;z-index:999}
+.toast{padding:10px 16px;border-radius:8px;font-size:13px;font-weight:600;
+  animation:slideIn .3s ease;max-width:300px;box-shadow:var(--shadow)}
+.toast.success{background:color-mix(in srgb,var(--green) 15%,transparent);border:1px solid var(--green);color:var(--green)}
+.toast.error{background:color-mix(in srgb,var(--red) 15%,transparent);border:1px solid var(--red);color:var(--red)}
+.toast.info{background:color-mix(in srgb,var(--accent) 15%,transparent);border:1px solid var(--accent);color:var(--accent)}
+@keyframes slideIn{from{opacity:0;transform:translateX(40px)}to{opacity:1;transform:none}}
+
+::-webkit-scrollbar{width:8px;height:8px}
+::-webkit-scrollbar-track{background:var(--surface)}
+::-webkit-scrollbar-thumb{background:var(--border);border-radius:4px}
+::-webkit-scrollbar-thumb:hover{background:var(--muted)}
+
+.btn-theme{background:var(--surface2);border:1px solid var(--border);color:var(--muted);padding:6px 10px;border-radius:6px;font-size:13px}
+.btn-theme:hover{border-color:var(--accent);color:var(--accent)}
+.btn-theme::before{content:'Light'}
+[data-theme="light"] .btn-theme::before{content:'Dark'}
+</style>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/command_center_theme.css') }}">
+<script>(function(){var t=localStorage.getItem('uns-theme')||'light';document.documentElement.setAttribute('data-theme',t);})();</script>
+
+<!-- ── ISA-5.1ish Symbol Library (inline SVG sprite) ─────────────────────── -->
+<svg width="0" height="0" style="position:absolute" aria-hidden="true">
+<defs>
+  <symbol id="sym-tank" viewBox="0 0 60 60">
+    <rect x="10" y="10" width="40" height="40" rx="3" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="10" y1="20" x2="50" y2="20" stroke="currentColor" stroke-width="1" opacity=".5"/>
+    <line x1="30" y1="2" x2="30" y2="10" stroke="currentColor" stroke-width="2"/>
+    <line x1="30" y1="50" x2="30" y2="58" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-vessel" viewBox="0 0 60 60">
+    <path d="M14 12 H46 V42 Q46 50 30 50 Q14 50 14 42 Z" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="14" y1="12" x2="46" y2="12" stroke="currentColor" stroke-width="2"/>
+    <line x1="30" y1="2" x2="30" y2="12" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-silo" viewBox="0 0 60 60">
+    <path d="M10 15 H50 V45 L30 56 L10 45 Z" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="10" y1="15" x2="50" y2="15" stroke="currentColor" stroke-width="2"/>
+    <line x1="30" y1="2" x2="30" y2="15" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-pump" viewBox="0 0 60 60">
+    <circle cx="30" cy="30" r="18" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <polygon points="30,18 42,30 30,42 18,30" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="48" y1="30" x2="58" y2="30" stroke="currentColor" stroke-width="2"/>
+    <line x1="2" y1="30" x2="12" y2="30" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-motor" viewBox="0 0 60 60">
+    <rect x="8" y="20" width="36" height="20" rx="2" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <text x="26" y="34" font-size="14" fill="currentColor" text-anchor="middle" font-family="sans-serif" font-weight="700">M</text>
+    <line x1="44" y1="30" x2="58" y2="30" stroke="currentColor" stroke-width="2"/>
+    <circle cx="54" cy="30" r="3" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  </symbol>
+  <symbol id="sym-valve" viewBox="0 0 60 60">
+    <line x1="2" y1="30" x2="58" y2="30" stroke="currentColor" stroke-width="2"/>
+    <polygon points="14,18 14,42 30,30" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <polygon points="46,18 46,42 30,30" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="30" y1="14" x2="30" y2="6" stroke="currentColor" stroke-width="2"/>
+    <rect x="22" y="2" width="16" height="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  </symbol>
+  <symbol id="sym-mixer" viewBox="0 0 60 60">
+    <rect x="10" y="14" width="40" height="36" rx="2" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="30" y1="2" x2="30" y2="14" stroke="currentColor" stroke-width="2"/>
+    <line x1="30" y1="14" x2="30" y2="42" stroke="currentColor" stroke-width="2"/>
+    <line x1="20" y1="42" x2="40" y2="42" stroke="currentColor" stroke-width="2"/>
+    <line x1="22" y1="38" x2="22" y2="46" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="38" y1="38" x2="38" y2="46" stroke="currentColor" stroke-width="1.5"/>
+  </symbol>
+  <symbol id="sym-reactor" viewBox="0 0 60 60">
+    <ellipse cx="30" cy="14" rx="20" ry="6" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <ellipse cx="30" cy="46" rx="20" ry="6" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="10" y1="14" x2="10" y2="46" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="50" y1="14" x2="50" y2="46" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="30" y1="2" x2="30" y2="14" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-conveyor" viewBox="0 0 60 60">
+    <rect x="4" y="22" width="52" height="14" rx="2" fill="none" stroke="currentColor" stroke-width="2"/>
+    <circle cx="10" cy="29" r="6" fill="none" stroke="currentColor" stroke-width="2"/>
+    <circle cx="50" cy="29" r="6" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="20" y1="29" x2="40" y2="29" stroke="currentColor" stroke-width="1" stroke-dasharray="3 2"/>
+  </symbol>
+  <symbol id="sym-heat_exchanger" viewBox="0 0 60 60">
+    <rect x="6" y="20" width="48" height="20" rx="10" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="14" y1="20" x2="14" y2="40" stroke="currentColor" stroke-width="1.5" opacity=".6"/>
+    <line x1="22" y1="20" x2="22" y2="40" stroke="currentColor" stroke-width="1.5" opacity=".6"/>
+    <line x1="30" y1="20" x2="30" y2="40" stroke="currentColor" stroke-width="1.5" opacity=".6"/>
+    <line x1="38" y1="20" x2="38" y2="40" stroke="currentColor" stroke-width="1.5" opacity=".6"/>
+    <line x1="46" y1="20" x2="46" y2="40" stroke="currentColor" stroke-width="1.5" opacity=".6"/>
+    <line x1="2" y1="30" x2="6" y2="30" stroke="currentColor" stroke-width="2"/>
+    <line x1="54" y1="30" x2="58" y2="30" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-compressor" viewBox="0 0 60 60">
+    <circle cx="30" cy="30" r="20" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <text x="30" y="36" font-size="14" fill="currentColor" text-anchor="middle" font-family="sans-serif" font-weight="700">C</text>
+    <line x1="50" y1="30" x2="58" y2="30" stroke="currentColor" stroke-width="2"/>
+    <line x1="2" y1="30" x2="10" y2="30" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-boiler" viewBox="0 0 60 60">
+    <rect x="10" y="10" width="40" height="32" rx="4" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="30" y1="2" x2="30" y2="10" stroke="currentColor" stroke-width="2"/>
+    <path d="M22 50 Q26 42 30 50 Q34 42 38 50" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="14" y1="50" x2="46" y2="50" stroke="currentColor" stroke-width="2"/>
+    <text x="30" y="30" font-size="11" fill="currentColor" text-anchor="middle" font-family="sans-serif" font-weight="700">B</text>
+  </symbol>
+  <symbol id="sym-chiller" viewBox="0 0 60 60">
+    <rect x="10" y="14" width="40" height="32" rx="3" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="30" y1="22" x2="30" y2="38" stroke="currentColor" stroke-width="2"/>
+    <line x1="22" y1="30" x2="38" y2="30" stroke="currentColor" stroke-width="2"/>
+    <line x1="24" y1="24" x2="36" y2="36" stroke="currentColor" stroke-width="2"/>
+    <line x1="36" y1="24" x2="24" y2="36" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-dryer" viewBox="0 0 60 60">
+    <ellipse cx="30" cy="30" rx="22" ry="14" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <path d="M14 26 Q22 22 30 26 Q38 30 46 26" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+    <path d="M14 34 Q22 30 30 34 Q38 38 46 34" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+    <line x1="2" y1="30" x2="8" y2="30" stroke="currentColor" stroke-width="2"/>
+    <line x1="52" y1="30" x2="58" y2="30" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-filter" viewBox="0 0 60 60">
+    <rect x="14" y="10" width="32" height="40" rx="2" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="14" y1="20" x2="46" y2="20" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="14" y1="40" x2="46" y2="40" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="14" y1="22" x2="46" y2="38" stroke="currentColor" stroke-width="1" opacity=".5"/>
+    <line x1="46" y1="22" x2="14" y2="38" stroke="currentColor" stroke-width="1" opacity=".5"/>
+    <line x1="30" y1="2" x2="30" y2="10" stroke="currentColor" stroke-width="2"/>
+    <line x1="30" y1="50" x2="30" y2="58" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-centrifuge" viewBox="0 0 60 60">
+    <circle cx="30" cy="30" r="20" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <circle cx="30" cy="30" r="3" fill="currentColor"/>
+    <path d="M30 12 A18 18 0 0 1 48 30" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <polygon points="48,30 44,28 44,32" fill="currentColor"/>
+    <path d="M30 48 A18 18 0 0 1 12 30" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <polygon points="12,30 16,32 16,28" fill="currentColor"/>
+  </symbol>
+  <symbol id="sym-column" viewBox="0 0 60 60">
+    <rect x="22" y="4" width="16" height="52" rx="3" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="22" y1="14" x2="38" y2="14" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+    <line x1="22" y1="22" x2="38" y2="22" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+    <line x1="22" y1="30" x2="38" y2="30" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+    <line x1="22" y1="38" x2="38" y2="38" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+    <line x1="22" y1="46" x2="38" y2="46" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+  </symbol>
+  <symbol id="sym-clarifier" viewBox="0 0 60 60">
+    <path d="M6 20 H54 V36 L30 56 L6 36 Z" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <ellipse cx="30" cy="20" rx="24" ry="4" fill="none" stroke="currentColor" stroke-width="2"/>
+    <line x1="30" y1="2" x2="30" y2="20" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-screen" viewBox="0 0 60 60">
+    <line x1="6" y1="50" x2="54" y2="14" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="10" y1="46" x2="50" y2="18" stroke="currentColor" stroke-width="1" opacity=".6" stroke-dasharray="3 2"/>
+    <line x1="14" y1="42" x2="46" y2="22" stroke="currentColor" stroke-width="1" opacity=".4" stroke-dasharray="3 2"/>
+    <line x1="6" y1="50" x2="14" y2="50" stroke="currentColor" stroke-width="2"/>
+    <line x1="50" y1="14" x2="58" y2="14" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-mill" viewBox="0 0 60 60">
+    <path d="M16 6 L44 6 L40 22 L20 22 Z" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <circle cx="30" cy="38" r="14" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="30" y1="30" x2="30" y2="46" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="22" y1="38" x2="38" y2="38" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="24" y1="32" x2="36" y2="44" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="36" y1="32" x2="24" y2="44" stroke="currentColor" stroke-width="1.5"/>
+  </symbol>
+  <symbol id="sym-fan" viewBox="0 0 60 60">
+    <circle cx="30" cy="30" r="20" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <circle cx="30" cy="30" r="3" fill="currentColor"/>
+    <path d="M30 30 Q24 14 36 14 Q42 22 30 30" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M30 30 Q44 30 44 42 Q34 46 30 30" fill="none" stroke="currentColor" stroke-width="2"/>
+    <path d="M30 30 Q22 46 14 38 Q14 28 30 30" fill="none" stroke="currentColor" stroke-width="2"/>
+  </symbol>
+  <symbol id="sym-flowmeter" viewBox="0 0 60 60">
+    <line x1="2" y1="30" x2="58" y2="30" stroke="currentColor" stroke-width="2"/>
+    <circle cx="30" cy="30" r="14" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <text x="30" y="35" font-size="13" fill="currentColor" text-anchor="middle" font-family="sans-serif" font-weight="700">F</text>
+  </symbol>
+  <symbol id="sym-evaporator" viewBox="0 0 60 60">
+    <path d="M14 18 H46 V44 Q46 50 30 50 Q14 50 14 44 Z" fill="none" stroke="currentColor" stroke-width="2.5"/>
+    <line x1="14" y1="18" x2="46" y2="18" stroke="currentColor" stroke-width="2"/>
+    <path d="M22 14 Q24 10 22 6" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+    <path d="M30 14 Q32 10 30 6" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+    <path d="M38 14 Q40 10 38 6" fill="none" stroke="currentColor" stroke-width="1.5" opacity=".7"/>
+  </symbol>
+  <symbol id="sym-generic" viewBox="0 0 60 60">
+    <rect x="10" y="14" width="40" height="32" rx="3" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4 3"/>
+    <text x="30" y="36" font-size="14" fill="currentColor" text-anchor="middle" font-family="sans-serif" font-weight="700">?</text>
+  </symbol>
+</defs>
+</svg>
+</head>
+<body>
+
+{% include 'partials/sidebar.html' %}
+
+<header class="app-header">
+  <div class="header-brand">
+    <span class="logo">🏭</span>
+    <div>
+      <h1>Visualization</h1>
+      <span class="sub">UNS Design Studio</span>
+    </div>
+  </div>
+  <div class="header-right">
+    <button class="btn-theme" onclick="toggleTheme()" title="Toggle theme"></button>
+  </div>
+</header>
+
+<div class="tabs">
+  <button class="tab active" id="tab-wizard" onclick="switchTab('wizard')">1. Map equipment</button>
+  <button class="tab" id="tab-canvas" onclick="switchTab('canvas')">2. Layout &amp; links</button>
+  <span style="margin-left:auto;color:var(--muted);font-size:12px" id="status-line"></span>
+</div>
+
+<!-- ── View 1: Wizard ─────────────────────────────────────────────────────── -->
+<div class="view active" id="viewWizard">
+  <div class="wizard-head">
+    <div>
+      <h2>Step 1 — Map UNS entities to equipment kinds</h2>
+      <div class="sub">Pick what each site / area / work center / work unit represents. Saved to <code>visualization.json</code>.</div>
+    </div>
+    <div class="wizard-actions">
+      <button class="btn-secondary" onclick="acceptAllSuggestions()">Accept all suggestions</button>
+      <button class="btn-primary" onclick="saveMapping()">💾 Save mapping</button>
+    </div>
+  </div>
+  <div id="wizardBody">
+    <div class="empty-state"><h3>Loading…</h3></div>
+  </div>
+</div>
+
+<!-- ── View 2: Canvas ────────────────────────────────────────────────────── -->
+<div class="view" id="viewCanvas">
+  <div class="canvas-toolbar">
+    <span class="mode-badge view" id="mode-badge">VIEW</span>
+    <button class="tool-btn" id="btn-toggle-edit" onclick="toggleEdit()">✏️ Edit</button>
+    <span class="tool-divider"></span>
+    <label>Layout
+      <select id="layout-dir" onchange="onLayoutChange()">
+        <option value="TB">Top → Bottom</option>
+        <option value="LR" selected>Left → Right</option>
+      </select>
+    </label>
+    <label>Group
+      <select id="layout-group" onchange="onLayoutChange()">
+        <option value="none">none</option>
+        <option value="site" selected>site</option>
+      </select>
+    </label>
+    <button class="tool-btn" onclick="autoLayout()" title="Recompute auto layout (overwrites manual positions)">⊞ Auto-layout</button>
+    <span class="tool-divider"></span>
+    <span id="edit-tools" style="display:none;gap:6px;align-items:center;">
+      <button class="tool-btn active" data-tool="select" onclick="setTool('select')" title="Select / drag (S)">✥ Select</button>
+      <button class="tool-btn" data-tool="link" onclick="setTool('link')" title="Add link (L)">↔ Link</button>
+      <button class="tool-btn" data-tool="pipe" onclick="setTool('pipe')" title="Add pipe (P)">⛓ Pipe</button>
+      <button class="tool-btn" data-tool="gauge" onclick="setTool('gauge')" title="Add gauge (G)">📊 Gauge</button>
+      <button class="tool-btn" onclick="editSelectedGauge()" title="Edit selected gauge (E or dbl-click)">✎ Edit gauge</button>
+      <button class="tool-btn" onclick="deleteSelected()" title="Delete selected (Del)">🗑 Delete</button>
+      <span class="tool-divider"></span>
+      <button class="tool-btn" onclick="saveCanvas()" style="background:var(--accent);color:var(--on-accent);border-color:var(--accent)">💾 Save</button>
+    </span>
+    <span style="margin-left:auto;color:var(--muted);font-size:12px" id="canvas-info"></span>
+  </div>
+  <div class="canvas-host" id="canvas-host">
+    <div class="legend">
+      <div class="legend-section">Node border</div>
+      <div class="legend-row"><span class="legend-dot running"></span> Running</div>
+      <div class="legend-row"><span class="legend-dot fault"></span> Fault</div>
+      <div class="legend-row"><span class="legend-dot stopped"></span> Stopped</div>
+      <div class="legend-row"><span class="legend-dot neutral"></span> Container</div>
+      <div class="legend-section">LED widget</div>
+      <div class="legend-row"><span class="legend-dot led-on"></span> True / on</div>
+      <div class="legend-row"><span class="legend-dot led-off"></span> False / off</div>
+    </div>
+  </div>
+</div>
+
+<div id="toasts"></div>
+
+<!-- ── Gauge config modal ────────────────────────────────────────────────── -->
+<div id="gauge-modal" style="display:none" class="modal-overlay" onclick="if(event.target===this)closeGaugeModal()">
+  <div class="modal">
+    <div class="modal-head">
+      <span id="gm-modal-title">📊 Configure gauge</span>
+      <button class="modal-close" onclick="closeGaugeModal()">×</button>
+    </div>
+    <div class="modal-body">
+      <div style="font-size:11px;color:var(--muted)">Entity: <code id="gm-entity">—</code></div>
+      <label>Tag
+        <select id="gm-tag"></select>
+      </label>
+      <div class="modal-grid">
+        <label>Widget
+          <select id="gm-widget">
+            <option value="numeric">Numeric label</option>
+            <option value="gauge">Radial gauge</option>
+            <option value="bar">Horizontal bar</option>
+            <option value="led">LED (boolean)</option>
+            <option value="fill">Fill level</option>
+          </select>
+        </label>
+        <label>Label
+          <input id="gm-label" type="text" placeholder="(auto from tag)">
+        </label>
+        <label>Min
+          <input id="gm-min" type="number" value="0">
+        </label>
+        <label>Max
+          <input id="gm-max" type="number" value="100">
+        </label>
+        <label>Unit
+          <input id="gm-unit" type="text" placeholder="">
+        </label>
+        <label>Decimals
+          <input id="gm-decimals" type="number" value="1" min="0" max="3">
+        </label>
+      </div>
+    </div>
+    <div class="modal-foot">
+      <button class="btn-secondary" onclick="closeGaugeModal()">Cancel</button>
+      <button class="btn-primary" id="gm-confirm-btn" onclick="confirmGauge()">Add gauge</button>
+    </div>
+  </div>
+</div>
+
+<!-- dagre for hierarchical layout -->
+<script src="https://cdn.jsdelivr.net/npm/dagre@0.8.5/dist/dagre.min.js"></script>
+<!-- shared pure helpers (also unit-tested under tests-js/) -->
+<script src="{{ url_for('static', filename='js/viz_math.js') }}"></script>
+
+<script>
+const { widgetSize, clamp01, fmtNum, gaugePosition: _gaugePos,
+        arcEndpoints, ledColors, gaugeFraction } = window.VizMath;
+// ── Theme ───────────────────────────────────────────────────────────────────
+function toggleTheme(){
+  const cur = document.documentElement.getAttribute('data-theme') || 'dark';
+  const next = cur === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('uns-theme', next);
+}
+
+// ── Toasts ──────────────────────────────────────────────────────────────────
+function toast(msg, kind){
+  const el = document.createElement('div');
+  el.className = 'toast ' + (kind || 'info');
+  el.textContent = msg;
+  document.getElementById('toasts').appendChild(el);
+  setTimeout(()=>el.remove(), 3000);
+}
+
+// ── Tabs ────────────────────────────────────────────────────────────────────
+function switchTab(name){
+  document.getElementById('tab-wizard').classList.toggle('active', name==='wizard');
+  document.getElementById('tab-canvas').classList.toggle('active', name==='canvas');
+  document.getElementById('viewWizard').classList.toggle('active', name==='wizard');
+  document.getElementById('viewCanvas').classList.toggle('active', name==='canvas');
+  if (name==='canvas') renderCanvas();
+}
+
+// ── State ───────────────────────────────────────────────────────────────────
+const STATE = {
+  entities: [], kinds: [], cfg: null, status: null,
+  editMode: false, tool: 'select',
+  selected: null,    // {kind:'node'|'link'|'gauge', id|idx}
+  linkSource: null,
+  drag: null,
+  _prevGroup: null,
+  values: {},         // live tag values keyed by gauge id
+  liveTimer: null,
+  pendingGauge: null, // {entityId} while modal is open
+  openGroups: null,   // Set<siteKey> for wizard collapsibles; null = all open
+};
+
+// ── Load entities + saved viz config ────────────────────────────────────────
+async function loadAll(){
+  const [ent, cfg] = await Promise.all([
+    fetch('/api/viz/entities').then(r=>r.json()),
+    fetch('/api/viz/config').then(r=>r.json()),
+  ]);
+  STATE.entities = ent.entities || [];
+  STATE.kinds    = ent.kinds || [];
+  STATE.cfg      = cfg;
+  // initialize wizard groups expanded on first load
+  if (!(STATE.openGroups instanceof Set)){
+    STATE.openGroups = new Set(STATE.entities.map(siteKeyFor));
+  }
+  renderWizard();
+  updateStatusLine();
+}
+
+function updateStatusLine(){
+  const total   = STATE.entities.length;
+  const mapped  = STATE.entities.filter(e=>e.mapped).length;
+  document.getElementById('status-line').textContent =
+    `${mapped}/${total} entities mapped` + (STATE.cfg.lastModified ? ` · saved ${STATE.cfg.lastModified}` : ' · unsaved');
+}
+
+// ── Wizard render ───────────────────────────────────────────────────────────
+const TYPE_ORDER = { site: 0, area: 1, workCenter: 2, workUnit: 3 };
+
+function siteKeyFor(e){
+  // ISA-95 path: Enterprise|BU|Site|... — group by Site segment.
+  // Sites themselves use their own id as the group key.
+  const parts = e.id.split('|');
+  if (e.type === 'site') return e.id;
+  return parts.slice(0, 3).join('|');
+}
+
+function renderEntityRow(e){
+  const kindOpts = STATE.kinds.map(k =>
+    `<option value="${k}" ${k===e.kind?'selected':''}>${prettyKind(k)}</option>`).join('');
+  const sugLabel = e.mapped ? '' :
+    `<span class="suggestion-tag">→ suggested: ${prettyKind(e.suggestion)}</span>`;
+  return `<tr data-id="${escapeAttr(e.id)}">
+    <td><div class="kind-preview"><svg><use href="#sym-${e.kind}"/></svg></div></td>
+    <td><div class="entity-name">${escapeHtml(e.name)}</div>
+        <div class="entity-path">${escapeHtml(e.id)}</div></td>
+    <td><span class="entity-type-badge ${e.type}">${e.type}</span></td>
+    <td style="color:var(--muted);font-size:12px">${e.tags.length}</td>
+    <td><div class="kind-cell">
+      <select onchange="onKindChange(this)">${kindOpts}</select>
+      ${sugLabel}
+    </div></td>
+  </tr>`;
+}
+
+function renderWizard(){
+  const body = document.getElementById('wizardBody');
+  if (!STATE.entities.length){
+    body.innerHTML = '<div class="empty-state"><h3>No mappable entities</h3>'+
+      '<p>Add sites, areas, work centers, or work units in the <a href="/uns">UNS Designer</a> first.</p></div>';
+    return;
+  }
+
+  // Group entities by site key
+  const groups = new Map();
+  for (const e of STATE.entities){
+    const key = siteKeyFor(e);
+    if (!groups.has(key)) groups.set(key, { key, site: null, items: [] });
+    const g = groups.get(key);
+    g.items.push(e);
+    if (e.type === 'site') g.site = e;
+  }
+
+  // Sort each group's items: site, then area, wc, wu
+  for (const g of groups.values()){
+    g.items.sort((a, b) => {
+      const ta = TYPE_ORDER[a.type] ?? 99;
+      const tb = TYPE_ORDER[b.type] ?? 99;
+      if (ta !== tb) return ta - tb;
+      return a.id.localeCompare(b.id);
+    });
+  }
+
+  // Sort groups by site key
+  const ordered = [...groups.values()].sort((a, b) => a.key.localeCompare(b.key));
+
+  let html = '';
+  for (const g of ordered){
+    const total  = g.items.length;
+    const mapped = g.items.filter(e => e.mapped).length;
+    const siteName = g.site ? g.site.name : (g.key.split('|').pop() || g.key);
+    const stats = `${mapped}/${total} mapped`;
+    const isOpen = STATE.openGroups instanceof Set ? STATE.openGroups.has(g.key) : true;
+    html += `<details class="factory-group" data-key="${escapeAttr(g.key)}" ${isOpen?'open':''} ontoggle="onGroupToggle(this)">
+      <summary class="factory-head">
+        <span class="factory-name">${escapeHtml(siteName)}</span>
+        <span class="factory-path">${escapeHtml(g.key)}</span>
+        <span class="factory-stats">${stats}</span>
+      </summary>
+      <table class="entity-table"><thead><tr>
+        <th style="width:30px"></th>
+        <th>Entity</th>
+        <th style="width:90px">Type</th>
+        <th style="width:80px">Tags</th>
+        <th style="width:240px">Equipment kind</th>
+      </tr></thead><tbody>${g.items.map(renderEntityRow).join('')}</tbody></table>
+    </details>`;
+  }
+  body.innerHTML = html;
+}
+
+function onGroupToggle(el){
+  if (!(STATE.openGroups instanceof Set)) STATE.openGroups = new Set();
+  const key = el.getAttribute('data-key');
+  if (el.open) STATE.openGroups.add(key);
+  else STATE.openGroups.delete(key);
+}
+
+function prettyKind(k){
+  return k.replace(/_/g,' ').replace(/\b\w/g, c=>c.toUpperCase());
+}
+
+function onKindChange(sel){
+  const tr   = sel.closest('tr');
+  const id   = tr.getAttribute('data-id');
+  const kind = sel.value;
+  const e = STATE.entities.find(x => x.id === id);
+  if (!e) return;
+  e.kind   = kind;
+  e.mapped = true;
+  // refresh icon preview
+  const use = tr.querySelector('.kind-preview svg use');
+  if (use) use.setAttribute('href', '#sym-' + kind);
+  // remove suggestion tag
+  const tag = tr.querySelector('.suggestion-tag');
+  if (tag) tag.remove();
+  updateStatusLine();
+}
+
+function acceptAllSuggestions(){
+  for (const e of STATE.entities){
+    if (!e.mapped){
+      e.kind   = e.suggestion;
+      e.mapped = true;
+    }
+  }
+  renderWizard();
+  updateStatusLine();
+  toast('Suggestions applied — click Save to persist', 'info');
+}
+
+async function saveMapping(){
+  const cfg = STATE.cfg || { version:1, entities:{}, links:[], gauges:[], animations:[] };
+  cfg.entities = cfg.entities || {};
+  for (const e of STATE.entities){
+    if (e.mapped){
+      cfg.entities[e.id] = Object.assign({}, cfg.entities[e.id] || {}, { kind: e.kind });
+    }
+  }
+  const r = await fetch('/api/viz/config', {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify(cfg),
+  });
+  const d = await r.json();
+  if (d.ok){
+    toast('Mapping saved', 'success');
+    STATE.cfg = cfg;
+    cfg.lastModified = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+    updateStatusLine();
+  } else {
+    toast('Save failed', 'error');
+  }
+}
+
+// ── Canvas render ───────────────────────────────────────────────────────────
+async function fetchStatus(){
+  try {
+    const r = await fetch('/api/status');
+    STATE.status = await r.json();
+  } catch (e) {
+    STATE.status = null;
+  }
+}
+
+function plantStateColor(entity){
+  if (!STATE.status) return null;
+  const data = STATE.status.plant_data || {};
+  // Path layout: enterprise | businessUnit | site | area | workCenter | workUnit
+  const parts = (entity.id || '').split('|');
+  if (parts.length < 3) return null;
+  const group = parts[1], plant = parts[2];
+  const plantBlock = (data[group] || {})[plant];
+  if (!plantBlock) return null;
+  if (plantBlock.alarm)   return 'fault';
+  if (plantBlock.running) return 'running';
+  return 'stopped';
+}
+
+function buildGraph(entities, dir){
+  const g = new dagre.graphlib.Graph({ multigraph:false, compound:false });
+  g.setGraph({ rankdir: dir, nodesep: 30, ranksep: 60, marginx: 20, marginy: 20 });
+  g.setDefaultEdgeLabel(()=>({}));
+  const ids = new Set(entities.map(e=>e.id));
+  for (const e of entities){
+    g.setNode(e.id, { width: 110, height: 80, ...e });
+  }
+  for (const e of entities){
+    if (e.parentPath && ids.has(e.parentPath)){
+      g.setEdge(e.parentPath, e.id);
+    }
+  }
+  dagre.layout(g);
+  return g;
+}
+
+function svgEscape(s){ return String(s).replace(/[<>&"']/g, c=>({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c])); }
+function escapeHtml(s){ return svgEscape(s); }
+function escapeAttr(s){ return svgEscape(s); }
+
+function nodeColors(entity){
+  const state = plantStateColor(entity);
+  const colorVar = state === 'running' ? 'var(--green)'
+                : state === 'fault'   ? 'var(--red)'
+                : state === 'stopped' ? 'var(--muted)'
+                : entity.type === 'workUnit' ? 'var(--accent)'
+                : 'var(--border)';
+  return { stroke: colorVar };
+}
+
+// ── Edit-mode UI controls ───────────────────────────────────────────────────
+function toggleEdit(){
+  STATE.editMode = !STATE.editMode;
+  STATE.selected = null; STATE.linkSource = null; STATE.drag = null;
+  document.body.classList.toggle('canvas-edit', STATE.editMode);
+  const btn = document.getElementById('btn-toggle-edit');
+  btn.classList.toggle('active', STATE.editMode);
+  btn.textContent = STATE.editMode ? '✓ Done editing' : '✏️ Edit';
+  const badge = document.getElementById('mode-badge');
+  badge.className = 'mode-badge ' + (STATE.editMode?'edit':'view');
+  badge.textContent = STATE.editMode ? 'EDIT' : 'VIEW';
+  document.getElementById('edit-tools').style.display = STATE.editMode ? 'inline-flex' : 'none';
+  const grp = document.getElementById('layout-group');
+  if (STATE.editMode){
+    STATE._prevGroup = grp.value;
+    grp.value = 'none';
+    grp.disabled = true;
+  } else {
+    if (STATE._prevGroup) grp.value = STATE._prevGroup;
+    grp.disabled = false;
+  }
+  setTool('select');
+  renderCanvas();
+}
+
+function setTool(t){
+  STATE.tool = t;
+  STATE.linkSource = null;
+  document.querySelectorAll('#edit-tools .tool-btn[data-tool]').forEach(b=>{
+    b.classList.toggle('active', b.getAttribute('data-tool')===t);
+  });
+  const svg = document.querySelector('#canvas-host svg.scada');
+  if (svg){
+    svg.querySelectorAll('.viz-node.link-source').forEach(n=>n.classList.remove('link-source'));
+    const ghost = svg.querySelector('.ghost-link');
+    if (ghost) ghost.remove();
+  }
+}
+
+function onLayoutChange(){ renderCanvas(); }
+
+function autoLayout(){
+  if (!confirm('Recompute auto layout? This overwrites manual positions.')) return;
+  const ents = (STATE.cfg.entities = STATE.cfg.entities || {});
+  for (const id of Object.keys(ents)){
+    if (ents[id].layout) delete ents[id].layout;
+  }
+  for (const gg of (STATE.cfg.gauges || [])){
+    if (gg.layout) delete gg.layout;
+  }
+  renderCanvas();
+  toast('Auto layout recomputed (nodes + gauges) — Save to persist', 'info');
+}
+
+function editSelectedGauge(){
+  if (!STATE.editMode) return;
+  const sel = STATE.selected;
+  if (!sel || sel.kind !== 'gauge'){
+    toast('Select a gauge first (click it), then Edit', 'info');
+    return;
+  }
+  const gobj = (STATE.cfg.gauges||[]).find(g => g.id === sel.id);
+  if (!gobj){ toast('Gauge not found', 'error'); return; }
+  openGaugeModal(gobj.entity, gobj.id);
+}
+
+function deleteSelected(){
+  if (!STATE.editMode || !STATE.selected) return;
+  const sel = STATE.selected;
+  STATE.cfg.links = STATE.cfg.links || [];
+  STATE.cfg.entities = STATE.cfg.entities || {};
+  if (sel.kind === 'link'){
+    STATE.cfg.links.splice(sel.idx, 1);
+    toast('Link deleted', 'info');
+  } else if (sel.kind === 'gauge'){
+    STATE.cfg.gauges = (STATE.cfg.gauges||[]).filter(g => g.id !== sel.id);
+    toast('Gauge deleted', 'info');
+  } else if (sel.kind === 'node'){
+    if (STATE.cfg.entities[sel.id]) delete STATE.cfg.entities[sel.id];
+    STATE.cfg.links  = STATE.cfg.links.filter(l => l.from !== sel.id && l.to !== sel.id);
+    STATE.cfg.gauges = (STATE.cfg.gauges||[]).filter(g => g.entity !== sel.id);
+    toast('Mapping, gauges & links removed; entity remains in UNS config', 'info');
+  }
+  STATE.selected = null;
+  renderCanvas();
+}
+
+async function saveCanvas(){
+  const r = await fetch('/api/viz/config', {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify(STATE.cfg),
+  });
+  const d = await r.json();
+  if (d.ok){
+    toast('Layout & links saved', 'success');
+    STATE.cfg.lastModified = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+    updateStatusLine();
+  } else {
+    toast('Save failed', 'error');
+  }
+}
+
+// ── Gauge config modal ──────────────────────────────────────────────────────
+async function openGaugeModal(entityId, editId){
+  // editId !== undefined → editing an existing gauge; else adding new
+  const existing = editId
+    ? (STATE.cfg.gauges||[]).find(g => g.id === editId)
+    : null;
+  STATE.pendingGauge = { entityId, editId: editId || null };
+
+  const ent = STATE.entities.find(e => e.id === entityId);
+  if (!ent){ toast('Entity not found', 'error'); return; }
+  document.getElementById('gm-entity').textContent = entityId;
+  document.getElementById('gm-modal-title').textContent =
+    existing ? '📊 Edit gauge' : '📊 Configure gauge';
+  document.getElementById('gm-confirm-btn').textContent =
+    existing ? 'Save changes' : 'Add gauge';
+
+  // fetch tag list for this entity
+  const sel = document.getElementById('gm-tag');
+  sel.innerHTML = '<option>loading…</option>';
+  let tags = [];
+  try {
+    const r = await fetch('/api/viz/tags/' + encodeURIComponent(entityId));
+    const d = await r.json();
+    tags = d.tags || [];
+  } catch(e){}
+  if (!tags.length){
+    sel.innerHTML = '<option value="">(no tags on this entity)</option>';
+  } else {
+    sel.innerHTML = tags.map(t =>
+      `<option value="${escapeAttr(t.name)}" data-type="${escapeAttr(t.dataType)}" data-unit="${escapeAttr(t.unit)}">${escapeHtml(t.name)} · ${escapeHtml(t.dataType)}${t.unit?' ('+escapeHtml(t.unit)+')':''}</option>`
+    ).join('');
+  }
+  // Auto-pick widget by data type — only on initial load, never after the user
+  // has touched the widget dropdown (otherwise re-selecting the tag silently
+  // resets their explicit choice).
+  const widgetSel = document.getElementById('gm-widget');
+  let widgetUserPicked = false;
+  widgetSel.onchange = () => { widgetUserPicked = true; };
+
+  const onTagPick = (autoPickWidget) => {
+    const opt = sel.options[sel.selectedIndex];
+    if (!opt) return;
+    const dt   = opt.getAttribute('data-type') || 'Float';
+    const unit = opt.getAttribute('data-unit') || '';
+    document.getElementById('gm-unit').value  = unit;
+    document.getElementById('gm-label').value = opt.value;
+    if (autoPickWidget && !widgetUserPicked){
+      widgetSel.value = dt === 'Bool' ? 'led' : 'numeric';
+    }
+  };
+  sel.onchange = () => onTagPick(false);  // tag changes don't re-pick widget
+
+  if (existing){
+    // pre-populate from existing gauge — overrides the auto-pick defaults
+    if (tags.some(t => t.name === existing.tag)) sel.value = existing.tag;
+    document.getElementById('gm-widget').value   = existing.widget || 'numeric';
+    document.getElementById('gm-label').value    = existing.label  || '';
+    document.getElementById('gm-min').value      = existing.min ?? 0;
+    document.getElementById('gm-max').value      = existing.max ?? 100;
+    document.getElementById('gm-unit').value     = existing.unit  || '';
+    document.getElementById('gm-decimals').value = existing.decimals ?? 1;
+  } else if (tags.length) {
+    onTagPick(true);   // initial load only — auto-pick widget by data type
+  }
+  document.getElementById('gauge-modal').style.display = 'flex';
+  setTimeout(()=>sel.focus(), 50);
+}
+
+function closeGaugeModal(){
+  document.getElementById('gauge-modal').style.display = 'none';
+  STATE.pendingGauge = null;
+}
+
+function confirmGauge(){
+  const pg = STATE.pendingGauge;
+  if (!pg) return closeGaugeModal();
+  const tag = document.getElementById('gm-tag').value;
+  if (!tag){ toast('Pick a tag first', 'error'); return; }
+  const widget   = document.getElementById('gm-widget').value;
+  const label    = document.getElementById('gm-label').value || tag;
+  const minRaw   = document.getElementById('gm-min').value;
+  const maxRaw   = document.getElementById('gm-max').value;
+  const min      = minRaw === '' ? 0   : parseFloat(minRaw);
+  const max      = maxRaw === '' ? 100 : parseFloat(maxRaw);
+  const unit     = document.getElementById('gm-unit').value || '';
+  const decimals = parseInt(document.getElementById('gm-decimals').value, 10) || 0;
+
+  STATE.cfg.gauges = STATE.cfg.gauges || [];
+  if (pg.editId){
+    const g = STATE.cfg.gauges.find(x => x.id === pg.editId);
+    if (g){
+      Object.assign(g, { tag, widget, label, min, max, unit, decimals });
+      toast('Gauge updated — Save to persist', 'success');
+    } else {
+      toast('Gauge not found', 'error');
+    }
+  } else {
+    const id = `${pg.entityId}#${tag}#${Date.now().toString(36)}`;
+    STATE.cfg.gauges.push({
+      id, entity: pg.entityId, tag, widget, label,
+      min, max, unit, decimals,
+    });
+    toast('Gauge added — drag to position, then Save', 'success');
+  }
+  closeGaugeModal();
+  renderCanvas();
+}
+
+// ── Widget renderers ────────────────────────────────────────────────────────
+// widgetSize / clamp01 / fmtNum are imported from VizMath at top of script.
+
+function createGaugeGroup(g, position){
+  const sz = widgetSize(g.widget);
+  const grp = document.createElementNS(SVG_NS, 'g');
+  grp.setAttribute('class', 'viz-gauge');
+  grp.setAttribute('data-gauge-id', g.id);
+  grp.setAttribute('transform', `translate(${position.x} ${position.y})`);
+
+  const bg = document.createElementNS(SVG_NS, 'rect');
+  bg.setAttribute('class', 'gauge-bg');
+  bg.setAttribute('width',  sz.w);
+  bg.setAttribute('height', sz.h);
+  bg.setAttribute('rx', 4);
+  grp.appendChild(bg);
+
+  // label (top)
+  const lbl = document.createElementNS(SVG_NS, 'text');
+  lbl.setAttribute('class', 'gauge-label');
+  lbl.setAttribute('x', sz.w/2);
+  lbl.setAttribute('y', 11);
+  lbl.setAttribute('text-anchor', 'middle');
+  lbl.style.pointerEvents = 'none';
+  lbl.textContent = g.label.length > 14 ? g.label.slice(0,13)+'…' : g.label;
+  grp.appendChild(lbl);
+
+  // widget body — placeholder, populated by updateGaugeValue()
+  const body = document.createElementNS(SVG_NS, 'g');
+  body.setAttribute('class', 'gauge-body');
+  body.setAttribute('data-widget', g.widget);
+  buildWidgetBody(body, g, sz);
+  grp.appendChild(body);
+
+  const title = document.createElementNS(SVG_NS, 'title');
+  title.textContent = `${g.entity}\nTag: ${g.tag}\nWidget: ${g.widget}`;
+  grp.appendChild(title);
+
+  return grp;
+}
+
+function buildWidgetBody(body, g, sz){
+  body.innerHTML = '';  // works on SVG group too
+  while (body.firstChild) body.removeChild(body.firstChild);
+  const cx = sz.w/2;
+  if (g.widget === 'numeric'){
+    const t = document.createElementNS(SVG_NS, 'text');
+    t.setAttribute('class','gauge-value');
+    t.setAttribute('x', cx);
+    t.setAttribute('y', sz.h - 8);
+    t.setAttribute('text-anchor','middle');
+    t.setAttribute('font-size','18');   // larger than radial gauge for clear visual contrast
+    t.textContent = '—';
+    t.style.pointerEvents = 'none';
+    body.appendChild(t);
+    if (g.unit){
+      const u = document.createElementNS(SVG_NS, 'text');
+      u.setAttribute('class','gauge-unit');
+      u.setAttribute('x', sz.w - 4);
+      u.setAttribute('y', sz.h - 4);
+      u.setAttribute('text-anchor','end');
+      u.textContent = g.unit;
+      u.style.pointerEvents = 'none';
+      body.appendChild(u);
+    }
+  } else if (g.widget === 'gauge'){
+    // semicircle radial gauge — arc dome with value inside
+    const r  = Math.min(22, sz.w/2 - 8);
+    const cy = sz.h - 10;
+    const arc = (frac, cls) => {
+      const a0 = Math.PI, a1 = a0 - Math.PI*Math.max(0.0001, frac);
+      const x0 = cx + r*Math.cos(a0), y0 = cy - r*Math.sin(a0);
+      const x1 = cx + r*Math.cos(a1), y1 = cy - r*Math.sin(a1);
+      const p = document.createElementNS(SVG_NS, 'path');
+      p.setAttribute('class', cls);
+      p.setAttribute('d', `M ${x0} ${y0} A ${r} ${r} 0 0 1 ${x1} ${y1}`);
+      p.setAttribute('stroke-width', '5');
+      p.setAttribute('stroke-linecap','round');
+      return p;
+    };
+    body.appendChild(arc(1, 'gauge-arc-bg'));
+    const fg = arc(0.0001, 'gauge-arc-fg');
+    fg.setAttribute('d', `M ${cx - r} ${cy} A ${r} ${r} 0 0 1 ${cx - r} ${cy}`);
+    body.appendChild(fg);
+    const t = document.createElementNS(SVG_NS, 'text');
+    t.setAttribute('class','gauge-value');
+    t.setAttribute('x', cx);
+    t.setAttribute('y', cy - 4);
+    t.setAttribute('text-anchor','middle');
+    t.setAttribute('dominant-baseline','alphabetic');
+    t.setAttribute('font-size','12');
+    t.textContent = '—';
+    t.style.pointerEvents = 'none';
+    body.appendChild(t);
+  } else if (g.widget === 'bar'){
+    // Layout (sz.h=48): label@y=11, value@y=28, bar@y=34..44
+    const barH = 10;
+    const barY = sz.h - barH - 4;
+    const padX = 6;
+    const barW = sz.w - 2*padX;
+    const bg = document.createElementNS(SVG_NS, 'rect');
+    bg.setAttribute('class','gauge-bar-bg');
+    bg.setAttribute('x', padX); bg.setAttribute('y', barY);
+    bg.setAttribute('width', barW); bg.setAttribute('height', barH);
+    bg.setAttribute('rx', 2);
+    body.appendChild(bg);
+    const fg = document.createElementNS(SVG_NS, 'rect');
+    fg.setAttribute('class','gauge-bar-fg');
+    fg.setAttribute('x', padX); fg.setAttribute('y', barY);
+    fg.setAttribute('width', 0); fg.setAttribute('height', barH);
+    fg.setAttribute('rx', 2);
+    body.appendChild(fg);
+    const t = document.createElementNS(SVG_NS, 'text');
+    t.setAttribute('class','gauge-value');
+    t.setAttribute('x', cx);
+    t.setAttribute('y', barY - 6);
+    t.setAttribute('text-anchor','middle');
+    t.setAttribute('font-size','11');
+    t.textContent = '—';
+    t.style.pointerEvents = 'none';
+    body.appendChild(t);
+  } else if (g.widget === 'led'){
+    const c = document.createElementNS(SVG_NS, 'circle');
+    c.setAttribute('class','gauge-led');
+    c.setAttribute('cx', cx);
+    c.setAttribute('cy', sz.h - 12);
+    c.setAttribute('r', 6);
+    c.setAttribute('fill', 'var(--surface3)');
+    c.setAttribute('stroke', 'var(--border)');
+    body.appendChild(c);
+  } else if (g.widget === 'fill'){
+    const padX = 6, padY = 14;
+    const w = sz.w - 2*padX, h = sz.h - padY - 6;
+    const bg = document.createElementNS(SVG_NS, 'rect');
+    bg.setAttribute('class','gauge-fill-bg');
+    bg.setAttribute('x', padX); bg.setAttribute('y', padY);
+    bg.setAttribute('width', w); bg.setAttribute('height', h);
+    bg.setAttribute('rx', 2);
+    body.appendChild(bg);
+    const fg = document.createElementNS(SVG_NS, 'rect');
+    fg.setAttribute('class','gauge-fill-fg');
+    fg.setAttribute('x', padX); fg.setAttribute('y', padY + h);
+    fg.setAttribute('width', w); fg.setAttribute('height', 0);
+    fg.setAttribute('rx', 2);
+    body.appendChild(fg);
+    const t = document.createElementNS(SVG_NS, 'text');
+    t.setAttribute('class','gauge-value');
+    t.setAttribute('x', cx);
+    t.setAttribute('y', padY + h/2 + 4);
+    t.setAttribute('text-anchor','middle');
+    t.setAttribute('font-size','10');
+    t.textContent = '—';
+    t.style.pointerEvents = 'none';
+    body.appendChild(t);
+  }
+}
+
+function updateGaugeWidget(grp, g, value){
+  const sz = widgetSize(g.widget);
+  const body = grp.querySelector('.gauge-body');
+  if (!body) return;
+  const txt  = body.querySelector('.gauge-value');
+  if (g.widget === 'numeric'){
+    if (txt) txt.textContent = (value === null || value === undefined) ? '—' : fmtNum(Number(value), g.decimals);
+  } else if (g.widget === 'gauge'){
+    if (txt) txt.textContent = (value === null || value === undefined) ? '—' : fmtNum(Number(value), g.decimals);
+    const fg = body.querySelector('.gauge-arc-fg');
+    if (fg && value !== null && value !== undefined){
+      const frac = clamp01((Number(value) - g.min) / Math.max(0.0001, g.max - g.min));
+      const r  = Math.min(22, sz.w/2 - 8);
+      const cx = sz.w/2, cy = sz.h - 10;
+      if (frac <= 0){
+        fg.setAttribute('d', `M ${cx - r} ${cy} A ${r} ${r} 0 0 1 ${cx - r} ${cy}`);
+      } else {
+        const a0 = Math.PI, a1 = a0 - Math.PI*frac;
+        const x0 = cx + r*Math.cos(a0), y0 = cy - r*Math.sin(a0);
+        const x1 = cx + r*Math.cos(a1), y1 = cy - r*Math.sin(a1);
+        fg.setAttribute('d', `M ${x0} ${y0} A ${r} ${r} 0 0 1 ${x1} ${y1}`);
+      }
+    }
+  } else if (g.widget === 'bar'){
+    if (txt) txt.textContent = (value === null || value === undefined) ? '—' : fmtNum(Number(value), g.decimals) + (g.unit?' '+g.unit:'');
+    const fg = body.querySelector('.gauge-bar-fg');
+    if (fg && value !== null && value !== undefined){
+      const frac = clamp01((Number(value) - g.min) / Math.max(0.0001, g.max - g.min));
+      const padX = 6, barW = sz.w - 2*padX;
+      fg.setAttribute('width', frac * barW);
+    }
+  } else if (g.widget === 'led'){
+    const led = body.querySelector('.gauge-led');
+    if (led){
+      const cols = ledColors(value);
+      led.setAttribute('fill', cols.fill);
+      led.setAttribute('stroke', cols.stroke);
+    }
+  } else if (g.widget === 'fill'){
+    if (txt) txt.textContent = (value === null || value === undefined) ? '—' : fmtNum(Number(value), g.decimals);
+    const fg = body.querySelector('.gauge-fill-fg');
+    if (fg && value !== null && value !== undefined){
+      const frac = clamp01((Number(value) - g.min) / Math.max(0.0001, g.max - g.min));
+      const padX = 6, padY = 14, h = sz.h - padY - 6;
+      const fillH = frac * h;
+      fg.setAttribute('y', padY + (h - fillH));
+      fg.setAttribute('height', fillH);
+    }
+  }
+}
+
+// gaugePosition imported from VizMath (re-exported under same name for clarity)
+const gaugePosition = _gaugePos;
+
+// ── Live data ───────────────────────────────────────────────────────────────
+async function fetchLiveValues(){
+  try {
+    const r = await fetch('/api/viz/values');
+    const d = await r.json();
+    STATE.opcReady = d.opc_ready !== false;
+    STATE.values = STATE.opcReady ? (d.values || {}) : {};
+  } catch(e){
+    // transient fetch error — keep last-good values, just mark not-ready
+    STATE.opcReady = false;
+    STATE.values = {};
+  }
+  applyLiveValuesToDOM();
+  applyAutoAnimations();
+}
+
+function applyLiveValuesToDOM(){
+  const gauges = (STATE.cfg && STATE.cfg.gauges) || [];
+  for (const g of gauges){
+    const grp = document.querySelector(`.viz-gauge[data-gauge-id="${cssEscape(g.id)}"]`);
+    if (!grp) continue;
+    const v = STATE.values[g.id];
+    updateGaugeWidget(grp, g, v);
+  }
+}
+
+function applyAutoAnimations(){
+  // node spin: motor or pump kind, when site is running
+  document.querySelectorAll('svg.scada .viz-node').forEach(grp => {
+    const id = grp.getAttribute('data-id');
+    const e  = STATE.entities.find(x=>x.id===id);
+    if (!e) return;
+    const mapped = (STATE.cfg.entities||{})[id] || {};
+    const kind = mapped.kind || e.kind;
+    const isSpinKind = (kind === 'motor' || kind === 'pump' || kind === 'mixer' || kind === 'compressor' || kind === 'fan');
+    let running = false;
+    if (e.type === 'site'){
+      const st = plantStateColor(e);
+      running = (st === 'running');
+    } else {
+      // inherit from parent site
+      const parts = id.split('|');
+      if (parts.length >= 3){
+        const parentSiteId = parts.slice(0,3).join('|');
+        const parentSite = STATE.entities.find(x=>x.id===parentSiteId);
+        if (parentSite){
+          const st = plantStateColor(parentSite);
+          running = (st === 'running');
+        }
+      }
+    }
+    grp.classList.toggle('spinning', isSpinKind && running && !STATE.editMode);
+    // fault flash
+    if (e.type === 'site'){
+      const st = plantStateColor(e);
+      grp.classList.toggle('fault', st === 'fault' && !STATE.editMode);
+    }
+  });
+  // pipe flow: animate user pipes when their source's site is running
+  document.querySelectorAll('svg.scada .viz-link.user.pipe').forEach(path => {
+    const idx = parseInt(path.getAttribute('data-link-idx'),10);
+    const l = (STATE.cfg.links||[])[idx]; if (!l) return;
+    const srcEnt = STATE.entities.find(x=>x.id===l.from);
+    if (!srcEnt){ path.classList.remove('flowing'); return; }
+    let running = false;
+    const parts = l.from.split('|');
+    if (parts.length >= 3){
+      const parentSiteId = parts.slice(0,3).join('|');
+      const parentSite = STATE.entities.find(x=>x.id===parentSiteId);
+      if (parentSite) running = plantStateColor(parentSite) === 'running';
+    }
+    path.classList.toggle('flowing', running && !STATE.editMode);
+  });
+}
+
+function startLivePoll(){
+  stopLivePoll();
+  STATE.liveTimer = setInterval(()=>{
+    if (!document.getElementById('viewCanvas').classList.contains('active')) return;
+    if (STATE.editMode) return;
+    fetchLiveValues();
+  }, 1000);
+}
+function stopLivePoll(){
+  if (STATE.liveTimer){ clearInterval(STATE.liveTimer); STATE.liveTimer = null; }
+}
+
+// ── Node visual ─────────────────────────────────────────────────────────────
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function createNodeGroup(entity, n){
+  const w = n.width, h = n.height;
+  const x = n.x - w/2, y = n.y - h/2;
+  const c = nodeColors(entity);
+  const grp = document.createElementNS(SVG_NS, 'g');
+  grp.setAttribute('class', 'viz-node');
+  grp.setAttribute('data-id', entity.id);
+  grp.setAttribute('transform', `translate(${x} ${y})`);
+
+  const rect = document.createElementNS(SVG_NS, 'rect');
+  rect.setAttribute('width', w);
+  rect.setAttribute('height', h);
+  rect.setAttribute('rx', 6);
+  rect.setAttribute('fill', 'var(--surface)');
+  rect.setAttribute('stroke', c.stroke);
+  rect.setAttribute('stroke-width', '2');
+  grp.appendChild(rect);
+
+  const sym = document.createElementNS(SVG_NS, 'use');
+  sym.setAttribute('href', '#sym-' + (entity.kind || 'generic'));
+  sym.setAttribute('x', (w-44)/2);
+  sym.setAttribute('y', 6);
+  sym.setAttribute('width', 44);
+  sym.setAttribute('height', 44);
+  sym.setAttribute('color', c.stroke);
+  sym.style.pointerEvents = 'none';
+  grp.appendChild(sym);
+
+  const label = document.createElementNS(SVG_NS, 'text');
+  label.setAttribute('x', w/2);
+  label.setAttribute('y', h - 18);
+  label.setAttribute('text-anchor', 'middle');
+  label.setAttribute('font-size', '11');
+  label.setAttribute('font-family', 'system-ui, sans-serif');
+  label.setAttribute('font-weight', '600');
+  label.setAttribute('fill', 'var(--text)');
+  label.style.pointerEvents = 'none';
+  label.textContent = entity.name.length > 14 ? entity.name.slice(0,13)+'…' : entity.name;
+  grp.appendChild(label);
+
+  const sub = document.createElementNS(SVG_NS, 'text');
+  sub.setAttribute('x', w/2);
+  sub.setAttribute('y', h - 6);
+  sub.setAttribute('text-anchor', 'middle');
+  sub.setAttribute('font-size', '9');
+  sub.setAttribute('font-family', 'system-ui, sans-serif');
+  sub.setAttribute('fill', 'var(--muted)');
+  sub.style.pointerEvents = 'none';
+  sub.textContent = entity.type;
+  grp.appendChild(sub);
+
+  const title = document.createElementNS(SVG_NS, 'title');
+  title.textContent = entity.id + ' · ' + (entity.kind || 'generic');
+  grp.appendChild(title);
+
+  return grp;
+}
+
+function renderGraphSvg(entities, dir, container, opts){
+  opts = opts || {};
+  if (!entities.length){
+    container.innerHTML = '<div class="empty-state"><h3>No entities to render</h3>'+
+      '<p>Map entities in step 1 first.</p></div>';
+    return;
+  }
+  const g = buildGraph(entities, dir);
+  // override with saved coords (skipped when grouping → fresh per-card layout)
+  if (!opts.stripLayout){
+    for (const e of entities){
+      if (e.layout && Number.isFinite(e.layout.x) && Number.isFinite(e.layout.y)){
+        const n = g.node(e.id);
+        if (n){ n.x = e.layout.x; n.y = e.layout.y; }
+      }
+    }
+  }
+  // bbox — include nodes AND gauges so right/bottom widgets aren't clipped
+  let minX=Infinity, minY=Infinity, maxX=-Infinity, maxY=-Infinity;
+  for (const id of g.nodes()){
+    const n = g.node(id);
+    minX = Math.min(minX, n.x - n.width/2 - 30);
+    minY = Math.min(minY, n.y - n.height/2 - 30);
+    maxX = Math.max(maxX, n.x + n.width/2 + 30);
+    maxY = Math.max(maxY, n.y + n.height/2 + 30);
+  }
+  const gaugesAll = (STATE.cfg && STATE.cfg.gauges) || [];
+  const nodeMapForBbox = new Map();
+  for (const id of g.nodes()) nodeMapForBbox.set(id, g.node(id));
+  for (const gg of gaugesAll){
+    if (!nodeMapForBbox.has(gg.entity)) continue;
+    const sz = widgetSize(gg.widget);
+    const pos = gaugePosition(gg, nodeMapForBbox, gaugesAll);
+    minX = Math.min(minX, pos.x - 12);
+    minY = Math.min(minY, pos.y - 12);
+    maxX = Math.max(maxX, pos.x + sz.w + 12);
+    maxY = Math.max(maxY, pos.y + sz.h + 12);
+  }
+  // in edit mode give a generous workspace and ensure svg fills the viewport
+  // so users can drag nodes/gauges past the current content bbox without clipping
+  if (STATE.editMode){
+    const hostEl = document.getElementById('canvas-host');
+    const hostW = hostEl ? hostEl.clientWidth  : 0;
+    const hostH = hostEl ? hostEl.clientHeight : 0;
+    const contentW = maxX - minX;
+    const contentH = maxY - minY;
+    const wantW = Math.max(contentW + 800, hostW);
+    const wantH = Math.max(contentH + 500, hostH);
+    maxX = minX + wantW;
+    maxY = minY + wantH;
+  }
+  const w = Math.max(400, maxX - minX);
+  const h = Math.max(300, maxY - minY);
+
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'scada' + (STATE.editMode ? ' edit' : ''));
+  svg.setAttribute('width',  w);
+  svg.setAttribute('height', h);
+  svg.setAttribute('viewBox', `${minX} ${minY} ${w} ${h}`);
+  svg.setAttribute('data-graph-key', opts.key || 'all');
+
+  // parent edges (dotted, ISA-95 hierarchy)
+  const parentLayer = document.createElementNS(SVG_NS, 'g');
+  parentLayer.setAttribute('class', 'layer-parent-edges');
+  for (const ed of g.edges()){
+    const a = g.node(ed.v), b = g.node(ed.w);
+    if (!a || !b) continue;
+    const p = document.createElementNS(SVG_NS, 'path');
+    p.setAttribute('d', `M ${a.x} ${a.y} L ${b.x} ${b.y}`);
+    p.setAttribute('class', 'viz-link parent');
+    p.setAttribute('data-from', ed.v);
+    p.setAttribute('data-to', ed.w);
+    parentLayer.appendChild(p);
+  }
+  svg.appendChild(parentLayer);
+
+  // user links
+  const userLayer = document.createElementNS(SVG_NS, 'g');
+  userLayer.setAttribute('class', 'layer-user-links');
+  const links = (STATE.cfg && STATE.cfg.links) || [];
+  const idsInGraph = new Set(g.nodes());
+  links.forEach((l, idx) => {
+    if (!idsInGraph.has(l.from) || !idsInGraph.has(l.to)) return;
+    const a = g.node(l.from), b = g.node(l.to);
+    const p = document.createElementNS(SVG_NS, 'path');
+    p.setAttribute('d', `M ${a.x} ${a.y} L ${b.x} ${b.y}`);
+    p.setAttribute('class', `viz-link user ${l.kind || 'link'}`);
+    p.setAttribute('data-link-idx', idx);
+    if (STATE.selected && STATE.selected.kind === 'link' && STATE.selected.idx === idx)
+      p.classList.add('selected');
+    userLayer.appendChild(p);
+  });
+  svg.appendChild(userLayer);
+
+  // nodes
+  const nodeLayer = document.createElementNS(SVG_NS, 'g');
+  nodeLayer.setAttribute('class', 'layer-nodes');
+  for (const id of g.nodes()){
+    const n = g.node(id);
+    const e = entities.find(x => x.id === id) || n;
+    const grp = createNodeGroup(e, n);
+    if (STATE.selected && STATE.selected.kind === 'node' && STATE.selected.id === id)
+      grp.classList.add('selected');
+    if (STATE.linkSource === id)
+      grp.classList.add('link-source');
+    nodeLayer.appendChild(grp);
+  }
+  svg.appendChild(nodeLayer);
+
+  // gauges (filtered to entities present in this graph)
+  const gaugeLayer = document.createElementNS(SVG_NS, 'g');
+  gaugeLayer.setAttribute('class', 'layer-gauges');
+  const gauges = (STATE.cfg && STATE.cfg.gauges) || [];
+  const nodeMap = new Map();
+  for (const id of g.nodes()) nodeMap.set(id, g.node(id));
+  for (const gg of gauges){
+    if (!nodeMap.has(gg.entity)) continue;
+    const pos = gaugePosition(gg, nodeMap, gauges);
+    const ggrp = createGaugeGroup(gg, pos);
+    if (STATE.selected && STATE.selected.kind === 'gauge' && STATE.selected.id === gg.id)
+      ggrp.classList.add('selected');
+    gaugeLayer.appendChild(ggrp);
+  }
+  svg.appendChild(gaugeLayer);
+
+  // attach handlers
+  if (STATE.editMode){
+    attachEditHandlers(svg, g);
+  } else {
+    attachViewHandlers(svg);
+  }
+
+  // Note: caller is responsible for ensuring `container` is mounted in the
+  // document before applyLiveValuesToDOM is run; renderCanvas does that once
+  // at the end so both ungrouped and grouped (detached `inner` divs) work.
+  container.appendChild(svg);
+}
+
+function attachViewHandlers(svg){
+  // no-op for now (Phase C: hover gauges, click → details)
+}
+
+// ── Edit handlers ───────────────────────────────────────────────────────────
+function svgPoint(svg, ev){
+  const pt = svg.createSVGPoint();
+  pt.x = ev.clientX; pt.y = ev.clientY;
+  return pt.matrixTransform(svg.getScreenCTM().inverse());
+}
+
+function attachEditHandlers(svg, g){
+  svg.addEventListener('pointerdown', ev => onPointerDown(ev, svg, g));
+  svg.addEventListener('pointermove', ev => onPointerMove(ev, svg, g));
+  svg.addEventListener('pointerup',   ev => onPointerUp(ev, svg, g));
+  svg.addEventListener('pointercancel', ev => onPointerUp(ev, svg, g));
+  // dbl-click a gauge → open the config modal pre-populated for editing
+  svg.addEventListener('dblclick', ev => {
+    const gel = findGaugeGroup(ev.target);
+    if (!gel) return;
+    const id = gel.getAttribute('data-gauge-id');
+    const gobj = (STATE.cfg.gauges||[]).find(x => x.id === id);
+    if (!gobj) return;
+    ev.preventDefault();
+    openGaugeModal(gobj.entity, id);
+  });
+}
+
+function findNodeGroup(target){
+  while (target && target !== document){
+    if (target.classList && target.classList.contains('viz-node')) return target;
+    target = target.parentNode;
+  }
+  return null;
+}
+function findLinkPath(target){
+  if (target && target.classList && target.classList.contains('viz-link') && target.classList.contains('user'))
+    return target;
+  return null;
+}
+function findGaugeGroup(target){
+  while (target && target !== document){
+    if (target.classList && target.classList.contains('viz-gauge')) return target;
+    target = target.parentNode;
+  }
+  return null;
+}
+
+function onPointerDown(ev, svg, g){
+  const nodeEl  = findNodeGroup(ev.target);
+  const linkEl  = findLinkPath(ev.target);
+  const gaugeEl = findGaugeGroup(ev.target);
+
+  if (STATE.tool === 'select'){
+    if (gaugeEl){
+      const id = gaugeEl.getAttribute('data-gauge-id');
+      const gobj = (STATE.cfg.gauges||[]).find(x => x.id === id);
+      if (!gobj) return;
+      const p = svgPoint(svg, ev);
+      const xfm = gaugeEl.getAttribute('transform') || '';
+      const m = xfm.match(/translate\(\s*(-?[\d.]+)\s+(-?[\d.]+)\s*\)/);
+      const origX = m ? parseFloat(m[1]) : 0;
+      const origY = m ? parseFloat(m[2]) : 0;
+      STATE.selected = { kind:'gauge', id };
+      STATE.drag     = { kind:'gauge', id, startX: p.x, startY: p.y, origX, origY, svg, moved:false };
+      svg.setPointerCapture(ev.pointerId);
+      gaugeEl.classList.add('dragging','selected');
+      ev.preventDefault();
+    } else if (nodeEl){
+      const id = nodeEl.getAttribute('data-id');
+      const n  = g.node(id);
+      const p  = svgPoint(svg, ev);
+      STATE.selected = { kind:'node', id };
+      STATE.drag     = { kind:'node', id, startX: p.x, startY: p.y, origX: n.x, origY: n.y, svg, g, moved: false };
+      svg.setPointerCapture(ev.pointerId);
+      nodeEl.classList.add('dragging','selected');
+      ev.preventDefault();
+    } else if (linkEl){
+      const idx = parseInt(linkEl.getAttribute('data-link-idx'),10);
+      STATE.selected = { kind:'link', idx };
+      renderCanvas();
+    } else {
+      STATE.selected = null;
+      renderCanvas();
+    }
+  } else if (STATE.tool === 'link' || STATE.tool === 'pipe'){
+    if (nodeEl){
+      const id = nodeEl.getAttribute('data-id');
+      if (!STATE.linkSource){
+        STATE.linkSource = id;
+        nodeEl.classList.add('link-source');
+        const ghost = document.createElementNS(SVG_NS, 'path');
+        ghost.setAttribute('class', 'ghost-link');
+        ghost.setAttribute('d', '');
+        svg.appendChild(ghost);
+      } else if (STATE.linkSource !== id){
+        STATE.cfg.links = STATE.cfg.links || [];
+        STATE.cfg.links.push({ from: STATE.linkSource, to: id, kind: STATE.tool });
+        STATE.linkSource = null;
+        const ghost = svg.querySelector('.ghost-link'); if (ghost) ghost.remove();
+        renderCanvas();
+      } else {
+        STATE.linkSource = null;
+        nodeEl.classList.remove('link-source');
+        const ghost = svg.querySelector('.ghost-link'); if (ghost) ghost.remove();
+      }
+    }
+  } else if (STATE.tool === 'gauge'){
+    if (nodeEl){
+      const id = nodeEl.getAttribute('data-id');
+      openGaugeModal(id);
+    }
+  }
+}
+
+function onPointerMove(ev, svg, g){
+  if (STATE.drag && STATE.drag.kind === 'gauge'){
+    const d = STATE.drag;
+    const p = svgPoint(svg, ev);
+    const newX = d.origX + (p.x - d.startX);
+    const newY = d.origY + (p.y - d.startY);
+    d.moved = true;
+    const gel = svg.querySelector(`.viz-gauge[data-gauge-id="${cssEscape(d.id)}"]`);
+    if (gel) gel.setAttribute('transform', `translate(${newX} ${newY})`);
+    return;
+  }
+  if (STATE.drag){
+    const d = STATE.drag;
+    const p = svgPoint(svg, ev);
+    const newX = d.origX + (p.x - d.startX);
+    const newY = d.origY + (p.y - d.startY);
+    const n = g.node(d.id); n.x = newX; n.y = newY;
+    d.moved = true;
+    const nodeEl = svg.querySelector(`.viz-node[data-id="${cssEscape(d.id)}"]`);
+    if (nodeEl) nodeEl.setAttribute('transform', `translate(${newX - n.width/2} ${newY - n.height/2})`);
+    svg.querySelectorAll('.viz-link.parent').forEach(path => {
+      const a = path.getAttribute('data-from'), b = path.getAttribute('data-to');
+      if (a === d.id || b === d.id){
+        const A = g.node(a), B = g.node(b);
+        path.setAttribute('d', `M ${A.x} ${A.y} L ${B.x} ${B.y}`);
+      }
+    });
+    svg.querySelectorAll('.viz-link.user').forEach(path => {
+      const idx = parseInt(path.getAttribute('data-link-idx'),10);
+      const l = STATE.cfg.links[idx]; if (!l) return;
+      if (l.from === d.id || l.to === d.id){
+        const A = g.node(l.from), B = g.node(l.to);
+        if (A && B) path.setAttribute('d', `M ${A.x} ${A.y} L ${B.x} ${B.y}`);
+      }
+    });
+    // also drag any gauges attached to this node, if they don't have explicit layout
+    svg.querySelectorAll('.viz-gauge').forEach(gel => {
+      const gid = gel.getAttribute('data-gauge-id');
+      const gg = (STATE.cfg.gauges||[]).find(x=>x.id===gid);
+      if (!gg || gg.entity !== d.id || (gg.layout && Number.isFinite(gg.layout.x))) return;
+      const sz = widgetSize(gg.widget);
+      gel.setAttribute('transform', `translate(${newX + n.width/2 + 12} ${newY - sz.h/2})`);
+    });
+  } else if (STATE.linkSource){
+    const A = g.node(STATE.linkSource);
+    if (!A) return;
+    const p = svgPoint(svg, ev);
+    let ghost = svg.querySelector('.ghost-link');
+    if (!ghost){
+      ghost = document.createElementNS(SVG_NS, 'path');
+      ghost.setAttribute('class', 'ghost-link');
+      svg.appendChild(ghost);
+    }
+    ghost.setAttribute('d', `M ${A.x} ${A.y} L ${p.x} ${p.y}`);
+  }
+}
+
+function onPointerUp(ev, svg, g){
+  if (STATE.drag && STATE.drag.kind === 'gauge'){
+    const d = STATE.drag;
+    const gel = svg.querySelector(`.viz-gauge[data-gauge-id="${cssEscape(d.id)}"]`);
+    let moved = false;
+    if (gel){
+      gel.classList.remove('dragging');
+      if (d.moved){
+        moved = true;
+        const xfm = gel.getAttribute('transform') || '';
+        const m = xfm.match(/translate\(\s*(-?[\d.]+)\s+(-?[\d.]+)\s*\)/);
+        if (m){
+          const gobj = (STATE.cfg.gauges||[]).find(x => x.id === d.id);
+          if (gobj) gobj.layout = { x: parseFloat(m[1]), y: parseFloat(m[2]) };
+        }
+      }
+    }
+    try { svg.releasePointerCapture(ev.pointerId); } catch (e) {}
+    STATE.drag = null;
+    // Re-render so the SVG viewBox/size grows to fit the new gauge position
+    // (otherwise dragging past the original bbox clips the widget).
+    if (moved) renderCanvas();
+    return;
+  }
+  if (STATE.drag){
+    const d = STATE.drag;
+    const n = g.node(d.id);
+    let moved = false;
+    if (d.moved){
+      moved = true;
+      STATE.cfg.entities = STATE.cfg.entities || {};
+      STATE.cfg.entities[d.id] = Object.assign({}, STATE.cfg.entities[d.id] || {}, {
+        layout: { x: n.x, y: n.y },
+      });
+    }
+    const nodeEl = svg.querySelector(`.viz-node[data-id="${cssEscape(d.id)}"]`);
+    if (nodeEl) nodeEl.classList.remove('dragging');
+    try { svg.releasePointerCapture(ev.pointerId); } catch (e) {}
+    STATE.drag = null;
+    if (moved) renderCanvas();
+  }
+}
+
+function cssEscape(s){
+  return String(s).replace(/[\\"]/g, '\\$&');
+}
+
+// ── Main canvas dispatch ────────────────────────────────────────────────────
+async function renderCanvas(){
+  await fetchStatus();
+  const host = document.getElementById('canvas-host');
+  const legend = host.querySelector('.legend');
+  host.innerHTML = '';
+  if (legend) host.appendChild(legend);
+
+  const dir   = document.getElementById('layout-dir').value;
+  const group = document.getElementById('layout-group').value;
+  const mapped = (STATE.cfg && STATE.cfg.entities) || {};
+  const ents = STATE.entities.map(e => ({
+    ...e,
+    kind:   (mapped[e.id]||{}).kind || e.kind,
+    layout: (mapped[e.id]||{}).layout || null,
+  }));
+
+  if (!ents.length){
+    host.innerHTML = '<div class="empty-state"><h3>No entities</h3></div>';
+    return;
+  }
+
+  if (group === 'none' || STATE.editMode){
+    renderGraphSvg(ents, dir, host, { key:'all' });
+  } else {
+    const sites = ents.filter(e=>e.type==='site');
+    if (!sites.length){
+      renderGraphSvg(ents, dir, host, { key:'all' });
+    } else {
+      const wrap = document.createElement('div');
+      wrap.style.cssText = 'display:flex;flex-direction:column;gap:14px;padding:14px';
+      for (const s of sites){
+        const card = document.createElement('div');
+        card.style.cssText = 'background:var(--surface);border:1px solid var(--border);' +
+          'border-radius:8px;padding:10px;overflow-x:auto';
+        const hdr = document.createElement('div');
+        hdr.style.cssText = 'font-size:13px;font-weight:600;margin-bottom:6px;color:var(--text)';
+        hdr.textContent = s.name + ' — ' + s.id;
+        card.appendChild(hdr);
+        const inner = document.createElement('div');
+        const subEnts = ents.filter(e => e.id === s.id || e.id.startsWith(s.id + '|'));
+        const ids = new Set(subEnts.map(e=>e.id));
+        const reroot = subEnts.map(e => ({...e, parentPath: ids.has(e.parentPath) ? e.parentPath : ''}));
+        renderGraphSvg(reroot, dir, inner, { key:'site:'+s.id, stripLayout:true });
+        card.appendChild(inner);
+        wrap.appendChild(card);
+      }
+      host.appendChild(wrap);
+    }
+  }
+
+  // Apply cached live values + animations after EVERY SVG is mounted in the
+  // document. This avoids the 1s blank flash on the 8s background re-render,
+  // including in group mode where SVGs are first attached to detached divs.
+  applyLiveValuesToDOM();
+  applyAutoAnimations();
+
+  document.getElementById('canvas-info').textContent =
+    `${ents.length} entities` +
+    (STATE.status ? ' · live state' : '') +
+    (STATE.editMode ? ' · EDITING (unsaved changes apply on Save)' : '');
+}
+
+// ── Keyboard shortcuts ──────────────────────────────────────────────────────
+document.addEventListener('keydown', ev => {
+  const onCanvas = document.getElementById('viewCanvas').classList.contains('active');
+  if (!onCanvas) return;
+  // ignore typing in inputs
+  if (['INPUT','SELECT','TEXTAREA'].includes((ev.target.tagName||'').toUpperCase())) return;
+  if (!STATE.editMode) return;
+  if (ev.key === 'Delete' || ev.key === 'Backspace'){
+    if (STATE.selected){ ev.preventDefault(); deleteSelected(); }
+  } else if (ev.key === 's' || ev.key === 'S') setTool('select');
+  else if (ev.key === 'l' || ev.key === 'L') setTool('link');
+  else if (ev.key === 'p' || ev.key === 'P') setTool('pipe');
+  else if (ev.key === 'g' || ev.key === 'G') setTool('gauge');
+  else if (ev.key === 'e' || ev.key === 'E'){ ev.preventDefault(); editSelectedGauge(); }
+  else if (ev.key === 'Escape'){
+    STATE.linkSource = null;
+    STATE.selected   = null;
+    renderCanvas();
+  }
+});
+
+// ── Boot ────────────────────────────────────────────────────────────────────
+loadAll();
+startLivePoll();   // 1 Hz live values + animations (skips when editing or off-canvas)
+// Slow background re-render to refresh state-color borders + plant_data.
+setInterval(()=>{
+  if (!document.getElementById('viewCanvas').classList.contains('active')) return;
+  if (STATE.editMode) return;
+  renderCanvas();
+}, 8000);
+</script>
+
+</body>
+</html>

--- a/tests-js/viz_math.test.js
+++ b/tests-js/viz_math.test.js
@@ -1,0 +1,204 @@
+/**
+ * Unit tests for static/js/viz_math.js — pure helpers used by the visualization.
+ * Runner: built-in node:test (no deps). Run with `npm test`.
+ */
+const { test } = require('node:test');
+const assert   = require('node:assert/strict');
+
+const VM = require('../static/js/viz_math.js');
+
+// ── widgetSize ──────────────────────────────────────────────────────────────
+test('widgetSize returns expected dims for each widget', () => {
+  assert.deepEqual(VM.widgetSize('gauge'),   { w: 70, h: 60 });
+  assert.deepEqual(VM.widgetSize('bar'),     { w: 90, h: 48 });
+  assert.deepEqual(VM.widgetSize('led'),     { w: 50, h: 32 });
+  assert.deepEqual(VM.widgetSize('fill'),    { w: 36, h: 56 });
+  assert.deepEqual(VM.widgetSize('numeric'), { w: 80, h: 32 });
+});
+
+test('widgetSize falls back to numeric for unknown widget', () => {
+  assert.deepEqual(VM.widgetSize('mystery'), { w: 80, h: 32 });
+  assert.deepEqual(VM.widgetSize(undefined), { w: 80, h: 32 });
+});
+
+// ── clamp01 ─────────────────────────────────────────────────────────────────
+test('clamp01 clamps to [0,1]', () => {
+  assert.equal(VM.clamp01(-5), 0);
+  assert.equal(VM.clamp01(0),  0);
+  assert.equal(VM.clamp01(0.5), 0.5);
+  assert.equal(VM.clamp01(1), 1);
+  assert.equal(VM.clamp01(99), 1);
+});
+
+// ── fmtNum ──────────────────────────────────────────────────────────────────
+test('fmtNum formats finite numbers with decimals', () => {
+  assert.equal(VM.fmtNum(3.14159, 2), '3.14');
+  assert.equal(VM.fmtNum(42, 0), '42');
+  assert.equal(VM.fmtNum(0.5, 1), '0.5');
+});
+
+test('fmtNum defaults decimals to 0', () => {
+  assert.equal(VM.fmtNum(1.999, undefined), '2');
+  assert.equal(VM.fmtNum(1.999, 0), '2');
+});
+
+test('fmtNum returns String(v) for non-finite', () => {
+  assert.equal(VM.fmtNum(NaN, 1), 'NaN');
+  assert.equal(VM.fmtNum(Infinity, 1), 'Infinity');
+  assert.equal(VM.fmtNum('abc', 1), 'abc');
+  assert.equal(VM.fmtNum(null, 1), 'null');
+});
+
+// ── gaugePosition ───────────────────────────────────────────────────────────
+test('gaugePosition uses explicit layout when present', () => {
+  const g = { entity: 'e1', widget: 'numeric', layout: { x: 100, y: 200 } };
+  const map = new Map([['e1', { x: 0, y: 0, width: 100, height: 60 }]]);
+  assert.deepEqual(VM.gaugePosition(g, map, [g]), { x: 100, y: 200 });
+});
+
+test('gaugePosition single-sibling places to the right of node, centered', () => {
+  const g = { entity: 'e1', widget: 'numeric' }; // h = 32
+  const node = { x: 100, y: 200, width: 100, height: 60 };
+  const map = new Map([['e1', node]]);
+  const p = VM.gaugePosition(g, map, [g]);
+  assert.equal(p.x, 100 + 50 + 12);    // node.x + width/2 + 12
+  assert.equal(p.y, 200 - 16);          // node.y - h/2 (widget top)
+});
+
+test('gaugePosition stacks multiple siblings vertically', () => {
+  const a = { entity: 'e1', widget: 'numeric' }; // h=32
+  const b = { entity: 'e1', widget: 'numeric' };
+  const c = { entity: 'e1', widget: 'numeric' };
+  const node = { x: 0, y: 0, width: 100, height: 60 };
+  const map = new Map([['e1', node]]);
+  const all = [a, b, c];
+  const pa = VM.gaugePosition(a, map, all);
+  const pb = VM.gaugePosition(b, map, all);
+  const pc = VM.gaugePosition(c, map, all);
+  // 3 widgets of height 32 with gap 6 → total 32*3 + 6*2 = 108 → first y = -54
+  assert.equal(pa.y, -54);
+  assert.equal(pb.y, -54 + 32 + 6);
+  assert.equal(pc.y, -54 + 2 * (32 + 6));
+  // all share same x
+  assert.equal(pa.x, pb.x);
+  assert.equal(pb.x, pc.x);
+});
+
+test('gaugePosition skips siblings that have explicit layout', () => {
+  const a = { entity: 'e1', widget: 'numeric' }; // h=32
+  const b = { entity: 'e1', widget: 'numeric', layout: { x: 999, y: 999 } };
+  const node = { x: 0, y: 0, width: 100, height: 60 };
+  const map = new Map([['e1', node]]);
+  // a is the only sibling without explicit layout → centered around node.y
+  const pa = VM.gaugePosition(a, map, [a, b]);
+  assert.equal(pa.y, -16); // node.y - h/2
+});
+
+test('gaugePosition fallback when entity is unmapped', () => {
+  const g = { entity: 'missing', widget: 'numeric' };
+  const map = new Map();
+  assert.deepEqual(VM.gaugePosition(g, map, [g]), { x: 20, y: 20 });
+});
+
+// ── arcEndpoints ────────────────────────────────────────────────────────────
+test('arcEndpoints with frac≈0 produces start point ≈ end point at left baseline', () => {
+  const e = VM.arcEndpoints(50, 50, 20, 0);
+  assert.equal(Math.round(e.x0), 30); // cx - r
+  assert.equal(Math.round(e.y0), 50);
+  // tip ≈ very close to baseline because frac clamped to 0.0001
+  assert.ok(Math.abs(e.x1 - 30) < 0.1);
+  assert.ok(Math.abs(e.y1 - 50) < 0.1);
+});
+
+test('arcEndpoints with frac=1 spans full semicircle (left → right baseline)', () => {
+  const e = VM.arcEndpoints(50, 50, 20, 1);
+  assert.equal(Math.round(e.x0), 30); // left
+  assert.equal(Math.round(e.y0), 50);
+  assert.equal(Math.round(e.x1), 70); // right
+  assert.equal(Math.round(e.y1), 50);
+});
+
+test('arcEndpoints with frac=0.5 ends at the dome top (cx, cy-r)', () => {
+  const e = VM.arcEndpoints(50, 50, 20, 0.5);
+  assert.equal(Math.round(e.x1), 50); // cx
+  assert.equal(Math.round(e.y1), 30); // cy - r (above baseline on screen)
+});
+
+test('arcEndpoints y0 always at baseline (sin(π)=0)', () => {
+  for (const frac of [0, 0.25, 0.5, 0.75, 1]) {
+    const e = VM.arcEndpoints(100, 100, 30, frac);
+    assert.ok(Math.abs(e.y0 - 100) < 0.0001, `frac=${frac} y0=${e.y0}`);
+  }
+});
+
+// ── computeBbox ─────────────────────────────────────────────────────────────
+test('computeBbox covers nodes with 30px padding and clamps to min 400x300', () => {
+  const nodes = [{ x: 100, y: 100, width: 100, height: 60 }];
+  const bb = VM.computeBbox(nodes, [], () => null);
+  assert.equal(bb.minX, 100 - 50 - 30);
+  assert.equal(bb.maxX, 100 + 50 + 30);
+  assert.equal(bb.w, 400);  // min clamp
+  assert.equal(bb.h, 300);
+});
+
+test('computeBbox stretches to include far gauge', () => {
+  const nodes = [{ x: 0, y: 0, width: 100, height: 60 }];
+  const gauges = [{ widget: 'numeric' }]; // 80x32
+  const getPos = () => ({ x: 1000, y: 0 });
+  const bb = VM.computeBbox(nodes, gauges, getPos);
+  // gauge right edge = 1000 + 80 + 12 = 1092
+  assert.equal(bb.maxX, 1092);
+});
+
+test('computeBbox returns sane defaults when no nodes', () => {
+  const bb = VM.computeBbox([], [], () => null);
+  assert.equal(bb.minX, 0);
+  assert.equal(bb.w, 400);
+  assert.equal(bb.h, 300);
+});
+
+// ── ledColors ───────────────────────────────────────────────────────────────
+test('ledColors null → no-data state', () => {
+  assert.deepEqual(VM.ledColors(null),
+    { fill: 'var(--surface3)', stroke: 'var(--border)' });
+  assert.deepEqual(VM.ledColors(undefined),
+    { fill: 'var(--surface3)', stroke: 'var(--border)' });
+});
+
+test('ledColors true / 1 / "True" → green', () => {
+  for (const v of [true, 1, 'True']) {
+    assert.deepEqual(VM.ledColors(v),
+      { fill: 'var(--green)', stroke: 'var(--green)' });
+  }
+});
+
+test('ledColors false / 0 / "False" → red', () => {
+  for (const v of [false, 0, 'False']) {
+    assert.deepEqual(VM.ledColors(v),
+      { fill: 'var(--red)', stroke: 'var(--red)' });
+  }
+});
+
+// ── gaugeFraction ───────────────────────────────────────────────────────────
+test('gaugeFraction maps value within range to [0,1]', () => {
+  assert.equal(VM.gaugeFraction(50, 0, 100), 0.5);
+  assert.equal(VM.gaugeFraction(0, 0, 100),  0);
+  assert.equal(VM.gaugeFraction(100, 0, 100), 1);
+});
+
+test('gaugeFraction clamps out-of-range', () => {
+  assert.equal(VM.gaugeFraction(-50, 0, 100), 0);
+  assert.equal(VM.gaugeFraction(200, 0, 100), 1);
+});
+
+test('gaugeFraction handles null/non-numeric', () => {
+  assert.equal(VM.gaugeFraction(null, 0, 100), 0);
+  assert.equal(VM.gaugeFraction(undefined, 0, 100), 0);
+  assert.equal(VM.gaugeFraction('abc', 0, 100), 0);
+});
+
+test('gaugeFraction protects against zero-width range', () => {
+  // max = min → divisor clamped to 0.0001 → very large positive deviation → clamped to 1
+  assert.equal(VM.gaugeFraction(5, 5, 5), 0);
+  assert.equal(VM.gaugeFraction(6, 5, 5), 1);
+});

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,90 @@
+"""Pytest fixtures for UNS Design Studio tests.
+
+Importing `app` triggers a daemon OPC-poll thread; that's harmless because the
+thread sleeps on connection failure. Each test gets isolated UNS + viz config
+files so we never touch the real ones.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+@pytest.fixture
+def app_module(tmp_path, monkeypatch):
+    """Import app.py with config paths redirected to a tmp dir."""
+    uns_path = tmp_path / 'uns_config.json'
+    viz_path = tmp_path / 'visualization.json'
+    uns_path.write_text(json.dumps(_DEFAULT_UNS), encoding='utf-8')
+
+    import app as app_mod
+    monkeypatch.setattr(app_mod, 'UNS_CONFIG_FILE', str(uns_path))
+    monkeypatch.setattr(app_mod, 'VIZ_CONFIG_FILE', str(viz_path))
+    return app_mod
+
+
+@pytest.fixture
+def flask_client(app_module):
+    app_module.app.testing = True
+    return app_module.app.test_client()
+
+
+@pytest.fixture
+def write_uns(app_module):
+    """Helper that overwrites the temp uns_config.json with given tree."""
+    def _write(tree):
+        with open(app_module.UNS_CONFIG_FILE, 'w', encoding='utf-8') as f:
+            json.dump({'tree': tree}, f)
+    return _write
+
+
+@pytest.fixture
+def write_viz(app_module):
+    def _write(cfg):
+        with open(app_module.VIZ_CONFIG_FILE, 'w', encoding='utf-8') as f:
+            json.dump(cfg, f)
+    return _write
+
+
+_DEFAULT_UNS = {
+    'tree': {
+        'name': 'Acme', 'type': 'enterprise',
+        'children': [
+            {
+                'name': 'NA', 'type': 'businessUnit',
+                'children': [
+                    {
+                        'name': 'plant-01', 'type': 'site',
+                        'children': [
+                            {
+                                'name': 'mixing', 'type': 'area',
+                                'children': [
+                                    {
+                                        'name': 'tank-01', 'type': 'workCenter',
+                                        'children': [
+                                            {
+                                                'name': 'pump-01', 'type': 'workUnit',
+                                                'tags': [
+                                                    {'name': 'flow_rate', 'dataType': 'Float',
+                                                     'unit': 'L/min'},
+                                                    {'name': 'running', 'dataType': 'Bool'},
+                                                    {'name': 'pressure', 'dataType': 'Float',
+                                                     'unit': 'bar', 'opcPath': 'mixing/pump-01/p'},
+                                                ],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+}

--- a/tests/test_resolve_tag_path.py
+++ b/tests/test_resolve_tag_path.py
@@ -1,0 +1,61 @@
+"""Tests for _viz_resolve_tag_path — UNS path → OPC path translation."""
+
+
+def test_resolve_simple_tag(app_module):
+    # default tag (no opcPath, no opcNodeName)
+    parts = app_module._viz_resolve_tag_path(
+        'Acme|NA|plant-01|mixing|tank-01|pump-01', 'flow_rate')
+    # 'Factory' prefix on site nodes
+    assert parts == ['NA', 'Factoryplant-01', 'mixing', 'tank-01', 'pump-01', 'flow_rate']
+
+
+def test_resolve_bool_tag(app_module):
+    parts = app_module._viz_resolve_tag_path(
+        'Acme|NA|plant-01|mixing|tank-01|pump-01', 'running')
+    assert parts[-1] == 'running'
+
+
+def test_resolve_with_opc_path_uses_area_root(app_module):
+    # 'pressure' has opcPath='mixing/pump-01/p' → area-relative override
+    parts = app_module._viz_resolve_tag_path(
+        'Acme|NA|plant-01|mixing|tank-01|pump-01', 'pressure')
+    # area_opc = ['NA', 'Factoryplant-01', 'mixing'] then split opcPath
+    assert parts == ['NA', 'Factoryplant-01', 'mixing', 'mixing', 'pump-01', 'p']
+
+
+def test_resolve_unknown_entity(app_module):
+    assert app_module._viz_resolve_tag_path('Acme|nope', 'flow_rate') == []
+
+
+def test_resolve_unknown_tag(app_module):
+    assert app_module._viz_resolve_tag_path(
+        'Acme|NA|plant-01|mixing|tank-01|pump-01', 'does_not_exist') == []
+
+
+def test_resolve_wrong_root(app_module):
+    assert app_module._viz_resolve_tag_path('Other|NA|plant-01', 'x') == []
+
+
+def test_resolve_empty_inputs(app_module):
+    assert app_module._viz_resolve_tag_path('', 'x') == []
+    assert app_module._viz_resolve_tag_path(None, 'x') == []
+
+
+def test_resolve_with_opc_node_name_override(app_module, write_uns):
+    write_uns({
+        'name': 'Acme', 'type': 'enterprise',
+        'children': [{
+            'name': 'plant-x', 'type': 'site',
+            'children': [{
+                'name': 'a1', 'type': 'area',
+                'children': [{
+                    'name': 'wu', 'type': 'workUnit',
+                    'tags': [{'name': 'temp', 'dataType': 'Float',
+                              'opcNodeName': 'TempReading'}],
+                }],
+            }],
+        }],
+    })
+    parts = app_module._viz_resolve_tag_path('Acme|plant-x|a1|wu', 'temp')
+    # site gets Factory prefix; opcNodeName replaces tag name as leaf
+    assert parts == ['Factoryplant-x', 'a1', 'wu', 'TempReading']

--- a/tests/test_suggest_kind.py
+++ b/tests/test_suggest_kind.py
@@ -1,0 +1,39 @@
+"""Tests for _suggest_kind heuristic."""
+import pytest
+
+
+@pytest.mark.parametrize('name,expected', [
+    ('water-tank-01',     'tank'),
+    ('Reservoir',         'tank'),
+    ('flour silo',        'silo'),
+    ('hopper-A',           'silo'),
+    ('PUMP-42',           'pump'),
+    ('main motor',        'motor'),
+    ('drive_unit',        'motor'),
+    ('valve V-01',        'valve'),
+    ('Mixer ALPHA',       'mixer'),
+    ('blender',           'mixer'),
+    ('agitator',          'mixer'),
+    ('reactor-1',         'reactor'),
+    ('fermenter',         'reactor'),
+    ('belt conveyor',     'conveyor'),
+    ('vessel-X',          'vessel'),
+    ('kettle 5',          'vessel'),
+    ('heat exchanger',    'heat_exchanger'),
+    ('heat-exchanger',    'heat_exchanger'),
+    ('hx-3',              'heat_exchanger'),
+    ('compressor',        'compressor'),
+    ('something-random',  'generic'),
+    ('',                  'generic'),
+])
+def test_suggest_kind(app_module, name, expected):
+    assert app_module._suggest_kind(name) == expected
+
+
+def test_suggest_kind_none(app_module):
+    assert app_module._suggest_kind(None) == 'generic'
+
+
+def test_suggest_kind_is_case_insensitive(app_module):
+    assert app_module._suggest_kind('TANK') == 'tank'
+    assert app_module._suggest_kind('Tank-99') == 'tank'

--- a/tests/test_viz_api.py
+++ b/tests/test_viz_api.py
@@ -1,0 +1,87 @@
+"""Tests for /api/viz/* HTTP endpoints via Flask test client."""
+
+
+def test_get_config_when_missing_returns_default(flask_client):
+    r = flask_client.get('/api/viz/config')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body['version'] == 1
+    assert body['entities'] == {}
+    assert body['gauges'] == []
+
+
+def test_post_config_persists_and_stamps_lastmodified(flask_client, app_module):
+    payload = {'entities': {'x': {'kind': 'tank'}}, 'gauges': []}
+    r = flask_client.post('/api/viz/config', json=payload)
+    assert r.status_code == 200
+    assert r.get_json()['ok'] is True
+
+    r2 = flask_client.get('/api/viz/config')
+    saved = r2.get_json()
+    assert saved['entities']['x']['kind'] == 'tank'
+    assert 'lastModified' in saved
+    assert saved['version'] == 1   # default injected
+
+
+def test_post_config_empty_body(flask_client):
+    r = flask_client.post('/api/viz/config', json={})
+    assert r.status_code == 200
+    assert r.get_json()['ok'] is True
+
+
+def test_get_entities_lists_mappable(flask_client):
+    r = flask_client.get('/api/viz/entities')
+    assert r.status_code == 200
+    body = r.get_json()
+    assert 'kinds' in body and 'entities' in body
+    ids = [e['id'] for e in body['entities']]
+    assert 'Acme|NA|plant-01' in ids
+    assert 'Acme|NA|plant-01|mixing|tank-01|pump-01' in ids
+
+
+def test_get_entities_includes_suggestion(flask_client):
+    body = flask_client.get('/api/viz/entities').get_json()
+    pump = next(e for e in body['entities'] if e['name'] == 'pump-01')
+    assert pump['suggestion'] == 'pump'
+    # not yet mapped
+    assert pump['mapped'] is False
+    assert pump['kind'] == 'pump'   # falls back to suggestion
+
+
+def test_get_entities_reflects_saved_mapping(flask_client, write_viz):
+    write_viz({
+        'version': 1,
+        'entities': {'Acme|NA|plant-01|mixing|tank-01|pump-01': {'kind': 'motor'}},
+        'gauges': [], 'links': [], 'animations': [],
+    })
+    body = flask_client.get('/api/viz/entities').get_json()
+    pump = next(e for e in body['entities'] if e['name'] == 'pump-01')
+    assert pump['mapped'] is True
+    assert pump['kind'] == 'motor'
+
+
+def test_get_tags_for_entity(flask_client):
+    r = flask_client.get('/api/viz/tags/Acme%7CNA%7Cplant-01%7Cmixing%7Ctank-01%7Cpump-01')
+    assert r.status_code == 200
+    body = r.get_json()
+    names = [t['name'] for t in body['tags']]
+    assert names == ['flow_rate', 'running', 'pressure']
+
+
+def test_values_endpoint_when_no_opc(flask_client, app_module):
+    # poll thread never connected — opc_connected starts False
+    app_module._state['viz_values'] = {}
+    app_module._state['opc_connected'] = False
+    body = flask_client.get('/api/viz/values').get_json()
+    assert body['values'] == {}
+    assert body['opc_ready'] is False
+    assert 'ts' in body
+
+
+def test_values_endpoint_with_cached_values(flask_client, app_module):
+    app_module._state['viz_values'] = {'g1': 42.0, 'g2': True}
+    app_module._state['opc_connected'] = True
+    body = flask_client.get('/api/viz/values').get_json()
+    assert body['values']['g1'] == 42.0
+    assert body['values']['g2'] is True
+    assert body['opc_ready'] is True

--- a/tests/test_viz_cfg_io.py
+++ b/tests/test_viz_cfg_io.py
@@ -1,0 +1,40 @@
+"""Tests for _load_viz_cfg / _save_viz_cfg I/O helpers."""
+import json
+import os
+
+
+def test_load_missing_returns_default(app_module):
+    # tmp viz path doesn't exist on first call
+    cfg = app_module._load_viz_cfg()
+    assert cfg == {'version': 1, 'entities': {}, 'links': [], 'gauges': [], 'animations': []}
+
+
+def test_save_roundtrip(app_module):
+    payload = {
+        'version': 1,
+        'entities': {'Acme|NA|plant-01': {'kind': 'tank'}},
+        'links': [{'from': 'a', 'to': 'b', 'kind': 'pipe'}],
+        'gauges': [{'id': 'g1', 'entity': 'e', 'tag': 't', 'widget': 'numeric',
+                    'min': 0, 'max': 100, 'unit': 'C'}],
+        'animations': [],
+    }
+    app_module._save_viz_cfg(payload)
+    assert os.path.exists(app_module.VIZ_CONFIG_FILE)
+    with open(app_module.VIZ_CONFIG_FILE, encoding='utf-8') as f:
+        on_disk = json.load(f)
+    assert on_disk == payload
+
+
+def test_load_malformed_returns_default(app_module):
+    with open(app_module.VIZ_CONFIG_FILE, 'w', encoding='utf-8') as f:
+        f.write('{ this is broken json')
+    cfg = app_module._load_viz_cfg()
+    assert cfg.get('gauges') == []
+    assert cfg.get('version') == 1
+
+
+def test_save_pretty_printed(app_module):
+    app_module._save_viz_cfg({'version': 1, 'gauges': [{'id': 'x'}]})
+    text = open(app_module.VIZ_CONFIG_FILE, encoding='utf-8').read()
+    # indent=2 produces newlines
+    assert '\n' in text

--- a/tests/test_walk_entities.py
+++ b/tests/test_walk_entities.py
@@ -1,0 +1,39 @@
+"""Tests for _walk_viz_entities — surfaces only mappable nodes."""
+
+
+def test_walks_default_tree(app_module):
+    out = app_module._walk_viz_entities()
+    ids = [e['id'] for e in out]
+    # enterprise + BU are skipped, site/area/workCenter/workUnit kept
+    assert 'Acme|NA|plant-01' in ids
+    assert 'Acme|NA|plant-01|mixing' in ids
+    assert 'Acme|NA|plant-01|mixing|tank-01' in ids
+    assert 'Acme|NA|plant-01|mixing|tank-01|pump-01' in ids
+    # enterprise root and BU not surfaced
+    assert 'Acme' not in ids
+    assert 'Acme|NA' not in ids
+
+
+def test_includes_tag_names(app_module):
+    out = app_module._walk_viz_entities()
+    pump = next(e for e in out if e['name'] == 'pump-01')
+    assert pump['tags'] == ['flow_rate', 'running', 'pressure']
+    assert pump['type'] == 'workUnit'
+    assert pump['parentPath'] == 'Acme|NA|plant-01|mixing|tank-01'
+
+
+def test_missing_uns_file_returns_empty(app_module, monkeypatch, tmp_path):
+    monkeypatch.setattr(app_module, 'UNS_CONFIG_FILE', str(tmp_path / 'nope.json'))
+    assert app_module._walk_viz_entities() == []
+
+
+def test_malformed_uns_file_returns_empty(app_module, tmp_path, monkeypatch):
+    bad = tmp_path / 'bad.json'
+    bad.write_text('{ this is not json', encoding='utf-8')
+    monkeypatch.setattr(app_module, 'UNS_CONFIG_FILE', str(bad))
+    assert app_module._walk_viz_entities() == []
+
+
+def test_empty_tree(app_module, write_uns):
+    write_uns({'name': 'Empty', 'type': 'enterprise', 'children': []})
+    assert app_module._walk_viz_entities() == []

--- a/uns_tree.py
+++ b/uns_tree.py
@@ -36,9 +36,34 @@ def sanitize_topic_part(value: str) -> str:
     return re.sub(r'[\s#+]', '_', value)
 
 
+def resolve_enterprise_root(tree: dict, default_name: str = 'GlobalFoodCo') -> tuple:
+    """Resolve the enterprise root node from a UNS tree.
+
+    Two layouts supported:
+      • Tree IS the enterprise (has 'name')   → (tree['name'], tree)
+      • Tree is a wrapper with one child     → (child['name'], child)
+    Falls back to (default_name, tree) when neither is present.
+    """
+    if not isinstance(tree, dict):
+        return (default_name, {})
+    name = tree.get('name', '')
+    if name:
+        return (name, tree)
+    for child in tree.get('children', []):
+        if isinstance(child, dict) and child.get('name'):
+            return (child['name'], child)
+    return (default_name, tree)
+
+
 def build_bridge_entries(tree: dict, sep: str, prefix: str) -> list:
-    """Walk the UNS config tree and return bridge entries for explicitly configured tags."""
+    """Walk the UNS config tree and return bridge entries for explicitly configured tags.
+
+    Walking starts at the enterprise node — wrapper trees are unwrapped so
+    opc_parts and topic always start with the enterprise name (matching the
+    OPC root created by factory.py).
+    """
     entries = []
+    _, enterprise_node = resolve_enterprise_root(tree)
 
     def _walk(node, uns_parts, opc_parts, area_opc_parts):
         ntype = node.get('type', '')
@@ -71,5 +96,5 @@ def build_bridge_entries(tree: dict, sep: str, prefix: str) -> list:
         for child in node.get('children', []):
             _walk(child, new_uns, new_opc, new_area_opc)
 
-    _walk(tree, [], [], [])
+    _walk(enterprise_node, [], [], [])
     return entries

--- a/viz_service.py
+++ b/viz_service.py
@@ -1,0 +1,185 @@
+"""Visualization helpers — pure logic, no Flask, no opcua dep.
+
+Equipment-kind heuristics, UNS→OPC path resolution, viz config I/O, and a
+gauge-value collector that takes the OPC traversal as a callable so this
+module stays import-clean and testable.
+"""
+
+import json
+import re
+
+
+EQUIPMENT_KINDS = [
+    'tank', 'pump', 'vessel', 'motor', 'valve', 'mixer',
+    'reactor', 'conveyor', 'silo', 'heat_exchanger', 'compressor',
+    'boiler', 'chiller', 'dryer', 'filter', 'centrifuge', 'column',
+    'clarifier', 'screen', 'mill', 'fan', 'flowmeter', 'evaporator',
+    'generic',
+]
+
+KIND_HEURISTICS = [
+    (r'\b(boiler|steam[\s_-]?gen)\b',                 'boiler'),
+    (r'\b(chiller|cooler|refrig|freezer)\b',          'chiller'),
+    (r'\b(dryer|drier|tumbler)\b',                    'dryer'),
+    (r'\b(filter|strainer)\b',                        'filter'),
+    (r'\b(centrifuge|separator|decanter)\b',          'centrifuge'),
+    (r'\b(column|tower|distill|absorber|stripper)\b', 'column'),
+    (r'\b(clarifier|settler|sediment|thickener)\b',   'clarifier'),
+    (r'\b(screen|sieve|sifter)\b',                    'screen'),
+    (r'\b(mill|grinder|crusher|shredder)\b',          'mill'),
+    (r'\b(fan|blower|exhaust)\b',                     'fan'),
+    (r'\b(flow[\s_-]?meter|flowmeter|\bfm\b)\b',      'flowmeter'),
+    (r'\b(evaporator|concentrator|blancher)\b',       'evaporator'),
+    (r'\b(tank|reservoir)\b',                         'tank'),
+    (r'\b(silo|hopper|bin)\b',                        'silo'),
+    (r'\b(pump)\b',                                   'pump'),
+    (r'\b(motor|drive)\b',                            'motor'),
+    (r'\b(valve)\b',                                  'valve'),
+    (r'\b(mixer|blender|agitator)\b',                 'mixer'),
+    (r'\b(reactor|fermenter)\b',                      'reactor'),
+    (r'\b(conveyor|belt)\b',                          'conveyor'),
+    (r'\b(vessel|kettle)\b',                          'vessel'),
+    (r'\b(heat[\s_-]?exchanger|hx)\b',                'heat_exchanger'),
+    (r'\b(compressor)\b',                             'compressor'),
+]
+
+DEFAULT_VIZ_CFG = {
+    'version': 1, 'entities': {}, 'links': [], 'gauges': [], 'animations': []
+}
+
+_MAPPABLE = {'site', 'area', 'workCenter', 'workUnit'}
+
+
+def suggest_kind(name: str) -> str:
+    """Return an equipment kind for a free-text name, else 'generic'."""
+    n = (name or '').lower().replace('_', ' ')
+    for pat, kind in KIND_HEURISTICS:
+        if re.search(pat, n):
+            return kind
+    return 'generic'
+
+
+def load_viz_cfg(path: str) -> dict:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return dict(DEFAULT_VIZ_CFG, entities={}, links=[], gauges=[], animations=[])
+
+
+def save_viz_cfg(path: str, data: dict):
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def _read_uns(path: str) -> dict:
+    try:
+        with open(path, encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def walk_entities(uns_config_path: str) -> list:
+    """Surfaces site / area / workCenter / workUnit nodes from the UNS tree.
+    Skips enterprise + BU + tags. Returns list of dicts ready for the editor."""
+    cfg = _read_uns(uns_config_path)
+    out = []
+
+    def walk(node, parts):
+        ntype = node.get('type', '')
+        name = node.get('name', '')
+        new_parts = parts + [name]
+        if ntype in _MAPPABLE:
+            out.append({
+                'id':         '|'.join(new_parts),
+                'name':       name,
+                'type':       ntype,
+                'parentPath': '|'.join(parts),
+                'tags':       [t.get('name') for t in node.get('tags', [])],
+            })
+        for child in node.get('children', []):
+            walk(child, new_parts)
+
+    walk(cfg.get('tree', {}), [])
+    return out
+
+
+def _find_node(tree: dict, parts: list):
+    """Walk a UNS tree by name path. Returns (node, opc_parts, area_opc) or None."""
+    if not parts or tree.get('name') != parts[0]:
+        return None
+    node = tree
+    opc_parts = []
+    area_opc = []
+    for name in parts[1:]:
+        child = next((c for c in node.get('children', []) if c.get('name') == name), None)
+        if not child:
+            return None
+        ntype = child.get('type', '')
+        opc_parts.append(('Factory' + name) if ntype == 'site' else name)
+        if ntype == 'area':
+            area_opc = list(opc_parts)
+        node = child
+    return node, opc_parts, area_opc
+
+
+def resolve_tag_path(uns_config_path: str, entity_id: str, tag_name: str) -> list:
+    """UNS entity id + tag name → OPC path list (from enterprise root).
+    Mirrors factory.py naming: 'Factory' prefix on site nodes, opcPath is
+    area-relative, opcNodeName overrides leaf."""
+    found = _find_node(_read_uns(uns_config_path).get('tree', {}), (entity_id or '').split('|'))
+    if not found:
+        return []
+    node, opc_parts, area_opc = found
+    for tag in node.get('tags', []):
+        if tag.get('name') != tag_name:
+            continue
+        if 'opcPath' in tag:
+            return area_opc + tag['opcPath'].split('/')
+        return opc_parts + [tag.get('opcNodeName', tag_name)]
+    return []
+
+
+def entity_tags(uns_config_path: str, entity_id: str) -> list:
+    """Tags on a UNS entity, shaped for the gauge config dropdown."""
+    found = _find_node(_read_uns(uns_config_path).get('tree', {}), entity_id.split('|'))
+    if not found:
+        return []
+    node, _, _ = found
+    out = []
+    for t in node.get('tags', []):
+        sim = t.get('simulation', {}) if isinstance(t.get('simulation'), dict) else {}
+        out.append({
+            'name':     t.get('name', ''),
+            'dataType': t.get('dataType', 'Float'),
+            'unit':     t.get('unit', ''),
+            'profile':  sim.get('profile', ''),
+        })
+    return out
+
+
+def collect_values(gauges: list, resolve_path, read_value) -> dict:
+    """Read OPC values for every gauge.
+      gauges       : list of {id?, entity, tag}
+      resolve_path : (entity, tag) -> list[str] | []
+      read_value   : (path: list[str]) -> primitive | None
+    Returns {gauge_id: value}. None when path or read fails.
+    """
+    out = {}
+    for g in gauges:
+        gid = g.get('id') or f"{g.get('entity', '')}#{g.get('tag', '')}"
+        path = resolve_path(g.get('entity', ''), g.get('tag', ''))
+        if not path:
+            out[gid] = None
+            continue
+        v = read_value(path)
+        if isinstance(v, bool):
+            out[gid] = v
+        elif isinstance(v, (int, float)):
+            out[gid] = v
+        elif hasattr(v, 'isoformat'):
+            out[gid] = v.isoformat()
+        else:
+            out[gid] = str(v) if v is not None else None
+    return out


### PR DESCRIPTION
## Summary

  Adds an interactive SCADA-style visualization to the UNS Studio dashboard, plus a small set of UNS-engine fixes uncovered while bringing it
  up against custom imported templates.

  ## Visualization

  **Frontend**
  - `templates/visualization.html` — wizard + read-only canvas, drag, links, pipes, persisted layout, gauges, widgets, animations, live data
  feed
  - `static/js/viz_math.js` — pure helpers (`gaugeFraction`, `ledColors`, layout math) extracted so they can be unit-tested in node without a
  browser
  - `static/css/command_center_theme.css` — minor polish
  - `templates/partials/sidebar.html` — Visualization nav link
  - `docs/UNS-CONTEXT.md` — viz design context

  > `visualization.json` is excluded — runtime layout is a state file.

  **Backend**
  - `viz_service.py` (new) — pure logic module: equipment-kind heuristics, UNS→OPC path resolution, viz config I/O, gauge value collection. No
   Flask, no `opcua` dep — fully testable
  - `app.py` — only thin Flask route handlers (`/viz`, `/api/viz/*`) and the OPC-traversal callable that bridges the live client into
  `viz_service.collect_values`
  - `_suggest_kind()` with expanded equipment heuristics — additive; existing matches preserved:
    - `boiler`, `chiller`, `dryer`, `filter`, `centrifuge`, `column`, `clarifier`, `screen`, `mill`, `fan`, `flowmeter`, `evaporator`
  - Underscore now treated as separator so `drive_unit` picks up `drive`
  - `viz_values` cleared on OPC disconnect to avoid stale gauge readings

  ## UNS engine fixes

  ### 1. Namespace URI now config-driven

  `factory.py` hardcoded `NAMESPACE_URI = "http://VirtualUNS.com/uns"` while `bridge.py` read `namespaceUri` from `uns_config.json`. Any
  imported template with a non-default `namespaceUri` broke the bridge with `list.index(x): x not in list` because the OPC server registered
  one URI and the bridge looked up another.

  **Fix:** `factory.py` and `app.py` now read `namespaceUri` from `uns_config.json` (with fallback to the legacy default).

  ### 2. Enterprise resolution tolerates wrapper trees

  `_get_enterprise_name()` did `tree.get('name', 'GlobalFoodCo')` — only worked when `tree` IS the enterprise.

  **Fix:** new `uns_tree.resolve_enterprise_root()` helper handles both layouts (tree-is-enterprise and wrapper-with-enterprise-child) and is
  used consistently in `factory.py`, `app.py`, and `build_bridge_entries`.

  ### 3. `dataType` alias tolerance

  `uns_config` templates used inconsistent `dataType` strings — pharma uses `"Boolean"` / `"Int32"`, food uses `"Bool"` / `"Int"`.
  `factory.py` only matched `"Bool"` / `"Int"`, so anything else fell through to Float Double, then Boolean simulation values were coerced to
  `0.0` in `run_simulation`'s float branch — which is why pharma `run-state` showed `0.0` in MQTT instead of `true`/`false`.

  **Fix:** accept common aliases.

  | Canonical  | Accepted aliases                                               |
  | ---------- | -------------------------------------------------------------- |
  | `Float`    | `Float`, `Double`, `Real`                                      |
  | `Int`      | `Int`, `Int16`, `Int32`, `Int64`, `Integer`, `UInt16/32/64`    |
  | `Bool`     | `Bool`, `Boolean`                                              |
  | `String`   | `String`, `Str`                                                |
  | `DateTime` | `DateTime`, `Timestamp`                                        |

  ### 4. Import-merge UX (`uns_editor.js`)

  Merge mode silently dropped the imported tree's enterprise wrapper (`name`, `namespaceUri`, `description`) and absorbed only its children.

  **Fix:** now warns via `confirm()` when:
  - imported wrapper metadata differs from current and would be dropped
  - top-level node names would collide with existing

  User can cancel before any state mutation.

  > Multi-enterprise support is a separate roadmap item — codebase still assumes one enterprise everywhere (single OPC root, `plant_key` has
  no enterprise prefix, etc.).

  ## Tests

  - `tests/` — pytest harness (`conftest.py`, Flask test client, tmp dirs)
  - `tests/test_viz_api.py`, `test_viz_cfg_io.py` — viz HTTP contract
  - `tests/test_walk_entities.py`, `test_suggest_kind.py` — viz helpers
  - `tests/test_resolve_tag_path.py` — OPC path resolution
  - `tests-js/viz_math.test.js` — node-test parity for canvas math
  - `package.json` — `npm test` script (no deps)
  - `pytest.ini`, `requirements-dev.txt` — config + dev pins

  **60 python tests + 25 JS tests pass.**